### PR TITLE
[Bug Fix] Modify Best Fitness Index to Argmax

### DIFF
--- a/pyperch/neural/ga_nn.py
+++ b/pyperch/neural/ga_nn.py
@@ -245,7 +245,7 @@ class GAModule(nn.Module):
 
         self.population = new_population
         values = new_values
-        best_fitness_index = np.argmin(values)
+        best_fitness_index = np.argmax(values)
 
         old_model = net.module_
         net.module_ = deepcopy(self.population[best_fitness_index])


### PR DESCRIPTION
I believe your best fitness index should be using argmax instead of argmin. Considering that you are using negative loss in your evaluate function. Most losses in pytorch perform minimization instead of maximization. Since you use negative loss, the best loss becomes the largest loss instead of the lowest loss. 

i.e.

Normal Loss = [0.3, 0.5, 0.7, 0.9] -> Argmin -> 0.3 is the best
Negative Loss = [-0.3, -0.5, -0.7, -0.9] -> Argmin -> 0.9 is "chosen" to be the best

I've modifying this and my F1 score shot up from 20% to 50% in an instant. Unless I'm missing a reason why you're implementing argmin. Please help approve the PR. Thanks