### PR TITLE
Add option to set torch/np random seeds to NN modules

### DIFF
--- a/pyperch/neural/backprop_nn.py
+++ b/pyperch/neural/backprop_nn.py
@@ -13,7 +13,7 @@ from skorch import NeuralNet
 
 
 class BackpropModule(nn.Module):
-    def __init__(self, layer_sizes, dropout_percent=0, activation=nn.ReLU(), output_activation=nn.Softmax(dim=-1)):
+    def __init__(self, layer_sizes, dropout_percent=0, activation=nn.ReLU(), output_activation=nn.Softmax(dim=-1), random_seed=None):
         """
 
         Initialize the neural network.
@@ -41,6 +41,8 @@ class BackpropModule(nn.Module):
         self.output_activation = output_activation
         self.layers = nn.ModuleList()
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        if random_seed is not None:
+            torch.manual_seed(random_seed)
 
         # Create layers based on layer_sizes
         for i in range(len(self.layer_sizes) - 1):

--- a/pyperch/neural/backprop_nn.py
+++ b/pyperch/neural/backprop_nn.py
@@ -13,7 +13,8 @@ from skorch import NeuralNet
 
 
 class BackpropModule(nn.Module):
-    def __init__(self, layer_sizes, dropout_percent=0, activation=nn.ReLU(), output_activation=nn.Softmax(dim=-1), random_seed=None):
+    def __init__(self, layer_sizes, dropout_percent=0, activation=nn.ReLU(), output_activation=nn.Softmax(dim=-1),
+                 random_seed=None):
         """
 
         Initialize the neural network.
@@ -41,8 +42,9 @@ class BackpropModule(nn.Module):
         self.output_activation = output_activation
         self.layers = nn.ModuleList()
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        if random_seed is not None:
-            torch.manual_seed(random_seed)
+        self.random_seed = random_seed
+        if self.random_seed is not None:
+            torch.manual_seed(self.random_seed)
 
         # Create layers based on layer_sizes
         for i in range(len(self.layer_sizes) - 1):

--- a/pyperch/neural/ga_nn.py
+++ b/pyperch/neural/ga_nn.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 
 class GAModule(nn.Module):
     def __init__(self, layer_sizes, population_size=300, to_mate=150, to_mutate=50, dropout_percent=0,
-                 step_size=.1, activation=nn.ReLU(), output_activation=nn.Softmax(dim=-1)):
+                 step_size=.1, activation=nn.ReLU(), output_activation=nn.Softmax(dim=-1), random_seed=None):
         """
 
          Initialize the neural network.
@@ -64,6 +64,10 @@ class GAModule(nn.Module):
         self.to_mate = to_mate
         self.to_mutate = to_mutate
         self.population = None
+        self.random_seed = random_seed
+        if self.random_seed is not None:
+            torch.manual_seed(self.random_seed)
+            np.random.seed(self.random_seed)
 
         # Create layers based on layer_sizes
         for i in range(len(self.layer_sizes) - 1):

--- a/pyperch/neural/rhc_nn.py
+++ b/pyperch/neural/rhc_nn.py
@@ -20,7 +20,7 @@ import copy
 
 class RHCModule(nn.Module):
     def __init__(self, layer_sizes, dropout_percent=0, step_size=.1, activation=nn.ReLU(),
-                 output_activation=nn.Softmax(dim=-1)):
+                 output_activation=nn.Softmax(dim=-1), random_seed=None):
         """
 
         Initialize the neural network.
@@ -52,6 +52,10 @@ class RHCModule(nn.Module):
         self.output_activation = output_activation
         self.layers = nn.ModuleList()
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.random_seed = random_seed
+        if self.random_seed is not None:
+            torch.manual_seed(self.random_seed)
+            np.random.seed(self.random_seed)
 
         # Create layers based on layer_sizes
         for i in range(len(self.layer_sizes) - 1):

--- a/pyperch/neural/sa_nn.py
+++ b/pyperch/neural/sa_nn.py
@@ -21,7 +21,7 @@ import math
 
 class SAModule(nn.Module):
     def __init__(self, layer_sizes, t=10000, cooling=.95, t_min=.001, dropout_percent=0, step_size=.1, activation=nn.ReLU(),
-                 output_activation=nn.Softmax(dim=-1)):
+                 output_activation=nn.Softmax(dim=-1), random_seed=None):
         """
 
         Initialize the neural network.
@@ -65,6 +65,10 @@ class SAModule(nn.Module):
         self.t = t
         self.cooling = cooling
         self.t_min = t_min
+        self.random_seed = random_seed
+        if self.random_seed is not None:
+            torch.manual_seed(self.random_seed)
+            np.random.seed(self.random_seed)
 
         # Create layers based on layer_sizes
         for i in range(len(self.layer_sizes) - 1):


### PR DESCRIPTION
Hi there, it seems the Backprop module only produces deterministic results if the torch seed is set in the init function. This should fix it by exposing a new optional parameter.