### PR TITLE
docs: add agentic development harness

### DIFF
--- a/.agents/skills/add-or-modify-optimizer/SKILL.md
+++ b/.agents/skills/add-or-modify-optimizer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: add-or-modify-optimizer
+description: Add or change a PyPerch randomized optimizer while preserving native PyTorch use, local optimizer conventions, and focused evidence. Use for optimizer implementation work, not search-only or documentation-only tasks.
+---
+
+# Add or modify an optimizer
+
+Read the repository [agent guide](../../../AGENTS.md) first. This workflow adds the
+optimizer-specific detail that does not belong in the always-loaded guide.
+
+## Establish the local contract
+
+1. Read the algorithm carefully enough to identify its state, proposal, acceptance,
+   evaluation, and randomization rules before choosing an API.
+2. Inspect `pyperch/optim/base.py`, neighboring optimizer implementations,
+   `tests/optim/`, the matching `examples/standalone/` directories, and
+   `docs/general_usage_guide.md`. Check public exports when adding a class.
+3. For a bug fix, reproduce the user-visible failure through a normal PyTorch usage
+   path before changing code.
+4. Follow local patterns where they express a shared contract, but do not
+   mechanically force different algorithms into identical implementations.
+
+## Design the smallest PyTorch-compatible API
+
+- Accept native PyTorch parameter iterables and preserve direct
+  `Optimizer(model.parameters(), ...)` usage and ordinary training loops.
+- Use closure evaluation when the algorithm needs to reevaluate a loss, following
+  the local optimizer pattern. Leave forward passes, loss construction, gradient
+  mode, evaluation, freezing, and device choices in normal PyTorch code.
+- Add only algorithm-specific options and state. Do not introduce trainers,
+  callbacks, model wrappers, estimator APIs, configuration layers, tensor or data
+  abstractions, or experiment-framework behavior.
+- Touch `pyperch/search/` or Optuna documentation only when the concern genuinely
+  belongs to hyperparameter search. Keep native Optuna trials and studies visible.
+
+## Implement consistently
+
+- Respect parameter groups, `requires_grad`, tensor dtype, and tensor device using
+  PyTorch operations. Preserve the public behavior of existing constructor defaults.
+- Follow the neighboring patterns for current and best parameters, best loss,
+  `restore_best()`, and the `function_evals`, `proposed_steps`, `accepted_steps`, and
+  `rejected_steps` counters. Adapt those patterns when the algorithm requires a
+  different meaning, and document the difference.
+- Consider reproducibility explicitly. Define how `random_state` affects proposals,
+  initialization, crossover, mutation, or acceptance, and avoid accidental reliance
+  on unrelated global random state.
+- Keep the patch focused. Record desirable adjacent refactors separately unless they
+  are required for correct behavior.
+
+## Supply evidence and usage
+
+- Add focused tests under `tests/optim/` for the algorithm behavior, validation,
+  counters and state, reproducibility where relevant, frozen parameters, and backward
+  compatibility affected by the change. Prefer observable behavior over private
+  implementation assertions.
+- Add or update a runnable example under `examples/standalone/<optimizer>/` that uses
+  a normal `torch.nn.Module`, native parameters, a loss closure, and an ordinary loop.
+- Update `docs/general_usage_guide.md`, public exports, and README links only as the
+  public change requires.
+
+## Validate and review
+
+Run the repository checks from `AGENTS.md`, including the focused optimizer tests and
+the runnable example when practical. Inspect the complete diff for API or abstraction
+creep, duplicated framework behavior, unrelated Optuna changes, stale documentation,
+secrets, local files, and generated artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# PyPerch agent guide
+
+PyPerch provides lightweight randomized optimizers for ordinary PyTorch models,
+plus a thin Optuna search layer for optional hyperparameter studies.
+
+## PyTorch first
+
+- Do not get in the way of PyTorch. Optimizers accept native parameter iterables,
+  including `model.parameters()`, and fit ordinary PyTorch training patterns.
+- PyPerch owns randomized optimizer behavior and the small amount of optimizer
+  state needed to operate on PyTorch parameters. It does not own model
+  architecture, tensors, data loading, losses, forward passes, training loops,
+  `torch.no_grad()`, parameter freezing, device handling, trainer frameworks,
+  callbacks, configuration DSLs, model wrappers, sklearn-style estimators, or a
+  replacement experiment framework. Use PyTorch abstractions for those concerns.
+- Keep Optuna native and visible. The search layer may coordinate a study, but it
+  must not hide Optuna trials, studies, or PyTorch training code.
+
+## Repository map
+
+| Path | Purpose |
+| --- | --- |
+| `pyperch/optim/` | PyTorch optimizer base and RHC, SA, and GA implementations |
+| `pyperch/search/` | Thin Optuna search support and small search utilities |
+| `tests/` | Focused optimizer and search tests |
+| `examples/standalone/` | Runnable PyTorch optimizer examples |
+| `examples/search/` | Runnable Optuna search example |
+| `docs/` | General optimizer and search usage guides |
+| `pyproject.toml` | Supported Python versions, dependencies, and tool settings |
+
+## Validation
+
+Keep changes small and follow neighboring implementations, tests, examples, and
+documentation. The repository checks used by CI are:
+
+```bash
+poetry run ruff format --check .
+poetry run ruff check .
+poetry run pytest
+```
+
+Run the checks relevant to the change, and run all three for runtime changes.
+Documentation-only work must still validate links, referenced paths and commands,
+scope, and the complete diff.
+
+## Security
+
+- Never commit, expose, print, log, or share secrets. Do not embed credentials in
+  source, tests, examples, docs, prompts, or committed configuration.
+- Never commit `.env` or similar local credential files, expose authenticated URLs,
+  private endpoints, or personal filesystem paths, or weaken existing ignore rules.
+- Use fake placeholders in examples and secure configuration such as environment
+  variables when credentials are required.
+- Do not add telemetry, network calls, downloads, or dependencies without a project
+  requirement.
+- Before handoff, inspect the final diff for credentials, sensitive information,
+  generated artifacts, and local files.
+
+## Skill routing
+
+| Task | Read |
+| --- | --- |
+| Add or change an optimizer | [`.agents/skills/add-or-modify-optimizer/SKILL.md`](.agents/skills/add-or-modify-optimizer/SKILL.md) |
+| Other work | This guide and the nearest implementation, test, example, and documentation |
+
+## Project documentation
+
+- [General Usage Guide](docs/general_usage_guide.md)
+- [Optuna Search Usage Guide](docs/search.md)
+- [Runnable examples](examples/standalone/)
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -68,3 +68,25 @@ See:
 # Contributing
 
 Pull requests are welcome.
+
+## Agent-assisted contributions
+
+Compatible coding agents should start with the canonical [agent guide](AGENTS.md).
+Claude Code loads the same guide through [`CLAUDE.md`](CLAUDE.md). Task-specific
+instructions are disclosed only when needed, such as the
+[`add-or-modify-optimizer`](.agents/skills/add-or-modify-optimizer/SKILL.md) skill.
+
+Repository-specific prompts can be concise:
+
+> Follow `AGENTS.md`. Compare `docs/search.md` with `pyproject.toml` and make only the
+> documentation corrections needed for accurate Optuna installation guidance.
+
+For a concrete follow-up that exercises the optimizer workflow:
+
+> Follow `AGENTS.md` and the `add-or-modify-optimizer` skill. Extend `GA` with an
+> optional uniform-crossover probability for choosing values from the first parent,
+> preserving the current hard-coded `0.5` behavior as the default, backward
+> compatibility, and native `model.parameters()` usage. Add focused tests, update a
+> runnable GA example, and document the option in the general usage guide. Do not
+> add framework abstractions or change the Optuna layer unless the concern genuinely
+> belongs there.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![PyPI](https://img.shields.io/pypi/v/pyperch.svg)
 ![Python Versions](https://img.shields.io/pypi/pyversions/pyperch.svg)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
-![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)
+![Code Style: Ruff](https://img.shields.io/badge/code%20style-ruff-261230.svg)
 ![Linter: Ruff](https://img.shields.io/badge/lint-ruff-blue.svg)
 [![CircleCI](https://dl.circleci.com/status-badge/img/circleci/WH9eaoZnQRJ8SGFDrvqQAd/5meq6x5R3uDA3KSuHARdVk/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/circleci/WH9eaoZnQRJ8SGFDrvqQAd/5meq6x5R3uDA3KSuHARdVk/tree/master)
 
@@ -51,7 +51,7 @@ See:
 
 [Examples](/examples/standalone/)
 
-[Optuna Search](/examples/search/optuna_search_example.py) 
+[Optuna Search](/examples/search/optuna_search_example.py)
 
 ---
 
@@ -61,7 +61,7 @@ See:
 
 [General Usage Guide](docs/general_usage_guide.md)
 
-[Search Usage Guide](docs/search.md) 
+[Search Usage Guide](docs/search.md)
 
 ---
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,19 +1,19 @@
 # Optuna Search Usage Guide
 
-The `pyperch.search` package provides an optional, lightweight wrapper for Optuna-based hyperparameter search.
+The `pyperch.search` package provides a lightweight wrapper for Optuna-based hyperparameter search.
 
-This layer is intended for quick experimentation, tuning, demos, and research workflows while remaining fully compatible with standard PyTorch training patterns. 
-PyPerch search utilities do not abstract or replace PyTorch training loops.  
-Optuna is an optional dependency. Calling `OptunaSearch.search(...)` without Optuna installed raises an `ImportError`.
+This layer is intended for quick experimentation, tuning, demos, and research workflows while remaining fully compatible with standard PyTorch training patterns.
+PyPerch search utilities do not abstract or replace PyTorch training loops.
+Optuna is installed as a PyPerch dependency. Calling `OptunaSearch.search(...)` without Optuna available raises an `ImportError`.
 
 ---
 
 # Installation
 
-Install the optional Optuna dependency:
+Install PyPerch and its dependencies:
 
 ```bash
-poetry install --extras optuna
+pip install pyperch
 ```
 
 ---
@@ -163,18 +163,8 @@ Supported directions:
 
 # Examples
 
-Examples are designed to be runnable in a standard Python environment, including Google Colab. In most cases, you should be able to pip install PyPerch then copy/paste the example code and run it. 
+Examples are designed to be runnable in a standard Python environment, including Google Colab. In most cases, you should be able to pip install PyPerch then copy/paste the example code and run it.
 
-*Note*: Search requires the optional Optuna dependency.
+Search requires Optuna, which is installed with PyPerch.
 
-```bash
-pip install pyperch optuna
-```
-
-Alternatively:
-
-```bash
-poetry install --extras "search"
-```
-
-[optuna_search_example.py](../examples/search/optuna_search_example.py) 
+[optuna_search_example.py](../examples/search/optuna_search_example.py)


### PR DESCRIPTION
## Intent

Build a lightweight, model-agnostic agentic development harness for PyPerch as a documentation-only change. Provide a short canonical AGENTS.md covering project purpose, PyTorch-first ownership boundaries, repository map, validation, security, skill routing, and documentation links; a minimal CLAUDE.md using the current supported import convention; one self-contained add-or-modify-optimizer skill with the recurring optimizer workflow; and an unobtrusive README contributor section with repository-specific prompts, including a concrete backward-compatible GA crossover follow-up. Keep PyTorch native, keep Optuna thin and visible, avoid duplicated guidance and extra agent infrastructure, do not change runtime code, optimizer or search implementations, tests, examples, or behavior, and validate links, paths, the Claude route, checks, scope, security, and the complete diff.

## What Changed

- Add a canonical agent guide, Claude Code routing, and a focused optimizer-development skill covering PyTorch-first boundaries, validation, security, and implementation workflow.
- Add agent-assisted contribution guidance and repository-specific prompts to the README, including a backward-compatible GA crossover follow-up.
- Align the README tooling badge and Optuna search documentation with the project’s configured formatter and required dependencies.

## Risk Assessment

✅ Low: The change is documentation-only, satisfies the stated harness requirements, references valid repository paths and commands, uses the supported Claude import syntax, and introduces no material correctness, security, compatibility, or maintenance risks.

## Testing

Inspected the complete diff, repaired the initially empty Poetry environment, ran the full automated test suite, manually verified the current Claude import convention, and captured an end-to-end routing and link transcript; all acceptance checks passed with no actionable issues, and transient test files were cleaned up.

<details>
<summary>Evidence: Agent harness acceptance evidence</summary>

`End-to-end transcript demonstrating documentation-only scope, Claude and skill routing, GA follow-up accuracy, 12 resolved local links, and available validation commands.`

```text
Documentation-only scope: PASS
Changed files: .agents/skills/add-or-modify-optimizer/SKILL.md, AGENTS.md, CLAUDE.md, README.md
Claude route: CLAUDE.md -> @AGENTS.md -> existing canonical guide: PASS
Canonical guide purpose, ownership, map, validation, security, routing, and docs: PASS
Optimizer task route and recurring workflow: PASS
README prompts and backward-compatible GA crossover follow-up: PASS
Local Markdown links and referenced paths (12): PASS
  .agents/skills/add-or-modify-optimizer/SKILL.md -> ../../../AGENTS.md
  AGENTS.md -> .agents/skills/add-or-modify-optimizer/SKILL.md
  AGENTS.md -> docs/general_usage_guide.md
  AGENTS.md -> docs/search.md
  AGENTS.md -> examples/standalone/
  README.md -> /examples/standalone/
  README.md -> /examples/search/optuna_search_example.py
  README.md -> docs/general_usage_guide.md
  README.md -> docs/search.md
  README.md -> AGENTS.md
  README.md -> CLAUDE.md
  README.md -> .agents/skills/add-or-modify-optimizer/SKILL.md
Documented validation command executables available through Poetry: PASS
End-user agent harness acceptance: PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat`, `git diff --name-status`, `git diff --check`, and complete diff inspection for `9e12b94..20fa777`</code>
- <code>`poetry run pytest` after repairing the isolated environment with `poetry install`</code>
- <code>End-to-end acceptance script validating scope, `CLAUDE.md` routing, canonical guide contents, optimizer skill routing and workflow, GA prompt accuracy, all local Markdown links, and Poetry command availability</code>
- <code>Checked the `@AGENTS.md` route against the official Claude Code `@path/to/import` convention</code>
- <code>Removed the transient worktree-local virtual environment with `poetry env remove --all` and verified no uncommitted source changes remained</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `pyperch/search/optuna.py:52` - The ImportError still calls Optuna optional and recommends `poetry install --extras optuna`, contradicting the required dependency in pyproject.toml. Changing runtime error text is outside this documentation-only pass.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
