### PR TITLE
fix(optim): preserve GA result and state invariants

### DIFF
--- a/docs/general_usage_guide.md
+++ b/docs/general_usage_guide.md
@@ -142,7 +142,9 @@ Parameters:
 - `population_size`: number of candidate solutions per generation.
 - `mutation_rate`: probability that each parameter value is mutated.
 - `step_size`: scale of random initialization and mutation noise.
-- `random_state`: optional seed for reproducible population sampling.
+- `random_state`: seed for GA's private random stream. An integer makes population
+  sampling reproducible without reading or changing PyTorch's global random state.
+  `None` creates a freshly seeded private stream.
 
 GA evolves a population using selection, crossover, and mutation.
 
@@ -173,4 +175,4 @@ Each example is designed to be runnable in a standard Python environment, includ
 
 [SA Examples](../examples/standalone/sa) 
 
-[GA Examples](../examples/standalone/ga) 
+[GA Examples](../examples/standalone/ga)

--- a/pyperch/optim/ga.py
+++ b/pyperch/optim/ga.py
@@ -57,9 +57,14 @@ class GA(RandomizedOptimizer):
         self.step_size = step_size
 
         self._generator = torch.Generator()
-        if random_state is not None:
+        if random_state is None:
+            self._generator.seed()
+        else:
             self._generator.manual_seed(random_state)
 
+    def reset_counters(self) -> None:
+        """Reset counters and run-specific state without changing parameters."""
+        super().reset_counters()
         self._initialized = False
         self._current_loss: float | None = None
         self._best_params: list[torch.Tensor] | None = None
@@ -83,14 +88,16 @@ class GA(RandomizedOptimizer):
         current_loss = self._current_loss
 
         population = self._initialize_population(current_params)
-        population_losses = self._evaluate_population(population, closure)
+        population_losses, _ = self._evaluate_population(population, closure)
 
         selected = self._select_population(population, population_losses)
         children = self._crossover(selected)
         children = self._mutate(children)
 
         candidate_population = selected + children
-        candidate_losses = self._evaluate_population(candidate_population, closure)
+        candidate_losses, result_template = self._evaluate_population(
+            candidate_population, closure
+        )
 
         best_idx = min(
             range(len(candidate_losses)),
@@ -111,12 +118,12 @@ class GA(RandomizedOptimizer):
                 self.best_loss = best_candidate_loss
                 self._best_params = self._clone_params()
 
-            return torch.tensor(best_candidate_loss)
+            return result_template.detach().new_tensor(best_candidate_loss)
 
         self._restore_params(current_params)
         self.rejected_steps += 1
 
-        return torch.tensor(current_loss)
+        return result_template.detach().new_tensor(current_loss)
 
     def _evaluate_loss(
         self,
@@ -139,12 +146,7 @@ class GA(RandomizedOptimizer):
             individual = []
 
             for param in base_params:
-                noise = torch.randn(
-                    param.shape,
-                    generator=self._generator,
-                    device=param.device,
-                    dtype=param.dtype,
-                )
+                noise = self._randn_like(param)
 
                 individual.append(param + self.step_size * noise)
 
@@ -156,7 +158,7 @@ class GA(RandomizedOptimizer):
         self,
         population: list[list[torch.Tensor]],
         closure: Callable[[], torch.Tensor],
-    ) -> list[float]:
+    ) -> tuple[list[float], torch.Tensor]:
         original = self._clone_params()
         losses = []
 
@@ -171,7 +173,7 @@ class GA(RandomizedOptimizer):
             losses.append(loss)
 
         self._restore_params(original)
-        return losses
+        return losses, loss_tensor
 
     def _select_population(
         self,
@@ -219,15 +221,7 @@ class GA(RandomizedOptimizer):
             child = []
 
             for p1, p2 in zip(parent1, parent2):
-                mask = (
-                    torch.rand(
-                        p1.shape,
-                        generator=self._generator,
-                        device=p1.device,
-                        dtype=p1.dtype,
-                    )
-                    < 0.5
-                )
+                mask = self._rand_like(p1) < 0.5
 
                 child_param = torch.where(mask, p1, p2)
                 child.append(child_param)
@@ -247,22 +241,8 @@ class GA(RandomizedOptimizer):
             new_individual = []
 
             for param in individual:
-                mutation_mask = (
-                    torch.rand(
-                        param.shape,
-                        generator=self._generator,
-                        device=param.device,
-                        dtype=param.dtype,
-                    )
-                    < self.mutation_rate
-                )
-
-                noise = torch.randn(
-                    param.shape,
-                    generator=self._generator,
-                    device=param.device,
-                    dtype=param.dtype,
-                )
+                mutation_mask = self._rand_like(param) < self.mutation_rate
+                noise = self._randn_like(param)
 
                 new_param = param + mutation_mask * self.step_size * noise
                 new_individual.append(new_param)
@@ -270,6 +250,20 @@ class GA(RandomizedOptimizer):
             mutated.append(new_individual)
 
         return mutated
+
+    def _rand_like(self, reference: torch.Tensor) -> torch.Tensor:
+        return torch.rand(
+            reference.shape,
+            generator=self._generator,
+            dtype=reference.dtype,
+        ).to(reference.device)
+
+    def _randn_like(self, reference: torch.Tensor) -> torch.Tensor:
+        return torch.randn(
+            reference.shape,
+            generator=self._generator,
+            dtype=reference.dtype,
+        ).to(reference.device)
 
     @staticmethod
     def _clone_individual(

--- a/tests/optim/test_ga.py
+++ b/tests/optim/test_ga.py
@@ -1,7 +1,37 @@
+import pytest
 import torch
 from torch import nn
 
 from pyperch.optim import GA
+
+
+def available_devices():
+    devices = [torch.device("cpu")]
+    if torch.cuda.is_available():
+        devices.append(torch.device("cuda"))
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        devices.append(torch.device("mps"))
+    return devices
+
+
+def run_ga_trajectory(random_state, unrelated_global_draws=0):
+    torch.manual_seed(1234)
+    torch.rand(unrelated_global_draws)
+
+    parameter = nn.Parameter(torch.zeros(4))
+    optimizer = GA(
+        [parameter],
+        population_size=6,
+        mutation_rate=1.0,
+        step_size=0.25,
+        random_state=random_state,
+    )
+
+    def closure():
+        return parameter.sum()
+
+    losses = [optimizer.step(closure).detach().clone() for _ in range(3)]
+    return torch.stack(losses), parameter.detach().clone()
 
 
 def make_classification_data(n=64, d=4):
@@ -112,29 +142,112 @@ def test_ga_respects_frozen_parameters():
         assert torch.equal(before, after)
 
 
-def test_ga_reset_counters():
-    torch.manual_seed(42)
-
-    X, y = make_classification_data()
-    model = nn.Sequential(nn.Linear(4, 8), nn.ReLU(), nn.Linear(8, 2))
-
-    criterion = nn.CrossEntropyLoss()
+@pytest.mark.parametrize("device", available_devices(), ids=str)
+@pytest.mark.parametrize("candidate_is_accepted", [True, False])
+def test_ga_preserves_loss_dtype_and_device_after_initialization(
+    device, candidate_is_accepted
+):
+    dtype = torch.float64 if device.type == "cpu" else torch.float32
+    parameter = nn.Parameter(torch.zeros(2, dtype=dtype, device=device))
     optimizer = GA(
-        model.parameters(),
-        population_size=8,
-        mutation_rate=0.1,
-        step_size=0.05,
+        [parameter],
+        population_size=4,
+        mutation_rate=0.5,
+        random_state=42,
+    )
+    evaluations = 0
+
+    def closure():
+        nonlocal evaluations
+        evaluations += 1
+        loss = parameter.square().sum()
+        if not candidate_is_accepted and evaluations > 1:
+            loss = loss + 1
+        return loss
+
+    initial_loss = optimizer.step(closure)
+    later_loss = optimizer.step(closure)
+
+    assert initial_loss.dtype == dtype
+    assert initial_loss.device == parameter.device
+    assert later_loss.dtype == dtype
+    assert later_loss.device == parameter.device
+    assert optimizer.accepted_steps == int(candidate_is_accepted)
+    assert optimizer.rejected_steps == int(not candidate_is_accepted)
+
+    best_parameters = parameter.detach().clone()
+    with torch.no_grad():
+        parameter.fill_(10)
+    optimizer.restore_best()
+
+    assert parameter.dtype == dtype
+    assert parameter.device == initial_loss.device
+    assert torch.equal(parameter, best_parameters)
+
+
+def test_ga_reset_counters_starts_fresh_best_state():
+    parameter = nn.Parameter(torch.tensor([0.0]))
+    optimizer = GA(
+        [parameter],
+        population_size=2,
+        mutation_rate=0.0,
+        step_size=0.01,
+        random_state=42,
     )
 
     def closure():
-        optimizer.zero_grad()
-        return criterion(model(X), y)
+        return parameter.square().sum()
 
     optimizer.step(closure)
-    optimizer.reset_counters()
 
-    assert optimizer.function_evals == 0
+    with torch.no_grad():
+        parameter.fill_(5)
+    optimizer.reset_counters()
+    fresh_loss = optimizer.step(closure)
+
+    assert fresh_loss.item() == 25
+    assert optimizer.best_loss == 25
+    assert optimizer.function_evals == 1
     assert optimizer.proposed_steps == 0
     assert optimizer.accepted_steps == 0
     assert optimizer.rejected_steps == 0
-    assert optimizer.best_loss is None
+
+    with torch.no_grad():
+        parameter.fill_(7)
+    optimizer.restore_best()
+
+    assert parameter.item() == 5
+
+
+def test_ga_same_seed_is_reproducible_and_global_rng_independent():
+    losses_a, parameters_a = run_ga_trajectory(42, unrelated_global_draws=1)
+    losses_b, parameters_b = run_ga_trajectory(42, unrelated_global_draws=100)
+
+    assert torch.equal(losses_a, losses_b)
+    assert torch.equal(parameters_a, parameters_b)
+
+
+def test_ga_different_seeds_diverge():
+    losses_a, parameters_a = run_ga_trajectory(1)
+    losses_b, parameters_b = run_ga_trajectory(2)
+
+    assert not torch.equal(losses_a, losses_b)
+    assert not torch.equal(parameters_a, parameters_b)
+
+
+@pytest.mark.parametrize("random_state", [42, None])
+def test_ga_does_not_perturb_global_rng(random_state):
+    torch.manual_seed(1234)
+    state_before = torch.random.get_rng_state()
+
+    run_ga_trajectory(random_state)
+
+    assert torch.equal(torch.random.get_rng_state(), state_before)
+
+
+def test_ga_none_uses_a_fresh_private_random_stream():
+    losses_a, parameters_a = run_ga_trajectory(None)
+    losses_b, parameters_b = run_ga_trajectory(None)
+
+    assert not torch.equal(losses_a, losses_b)
+    assert not torch.equal(parameters_a, parameters_b)


### PR DESCRIPTION
## Intent

Fix only the first correctness and state review cluster in the PyPerch genetic algorithm optimizer. Preserve the closure tensor dtype and device for all GA results and stored tensors after initialization, reproducing normal PyTorch usage with non-default floating dtype and reliable CPU plus available accelerator coverage, and compare against initialization and neighboring optimizers. Make reset_counters start a genuinely fresh GA best-state run without changing current model parameters or allowing stale loss or parameter snapshots to contaminate restore_best. Establish explicit random_state semantics: integer seeds use a private reproducible stream, different seeds diverge, unrelated global PyTorch RNG state is neither read nor perturbed, and None creates a fresh private stream while preserving the public default. Keep the patch narrowly limited to GA correctness and state, focused regression tests, and only documentation needed for random_state. Preserve existing PyTorch-first behavior, do not address other review findings, and validate the complete repository.

## What Changed

- Preserve closure tensor dtype and device across initialized GA results and stored best parameters, including accelerator-backed models.
- Make `reset_counters()` clear run-specific best state, and give seeded or `None` configurations isolated private random streams without affecting PyTorch's global RNG.
- Add focused regression coverage for result tensors, state resets, restoration, and RNG semantics, with corresponding `random_state` documentation.

## Risk Assessment

✅ Low: The focused GA changes consistently preserve loss metadata, isolate RNG state, and clear stale run state without changing model parameters; no material merge-blocking risks were found.

## Testing

After installing the missing declared dependencies, focused GA tests passed on CPU and MPS, the end-to-end public PyTorch workflow demonstrated every required dtype, device, reset, restore, and RNG behavior against initialization and neighboring optimizers, and the complete repository test suite passed. Generated environments and caches were removed while the evidence transcript was retained.

<details>
<summary>Evidence: GA correctness and state acceptance transcript</summary>

```text
GA correctness and state acceptance transcript
torch=2.12.0
GA public random_state default=None
GA device=cpu dtype=torch.float64 initial_result=0.19531250 later_result=0.14744086 restored_best_loss=0.14744086 stored_best_tensors_preserved=True
GA device=mps:0 dtype=torch.float32 initial_result=0.19531250 later_result=0.14744087 restored_best_loss=0.14744087 stored_best_tensors_preserved=True
neighbor=RHC device=cpu dtype=torch.float64 initial_result=0.19531250 later_result=0.19531250 restored_best_loss=0.19531250 stored_best_tensors_preserved=True
neighbor=SA device=cpu dtype=torch.float64 initial_result=0.19531250 later_result=0.17911271 restored_best_loss=0.17911271 stored_best_tensors_preserved=True
reset fresh run: parameter_after_reset=5.0 fresh_loss=25.0 best_loss=25.0 restore_best_parameter=5.0 stale_snapshot_used=False
integer seed reproducible across unrelated global draws: [0.0, -0.18284541368484497, -0.8121825456619263]
different integer seeds diverge: seed1=[0.0, -0.6569520831108093, -1.9221673011779785] seed2=[0.0, -1.088769793510437, -2.0703370571136475]
global RNG unchanged by integer and None streams: True
None streams are fresh: run1=[0.0, -1.106432318687439, -1.9101113080978394] run2=[0.0, -0.58262699842453, -2.2682743072509766]
END_TO_END_RESULT=PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 9c28d45f31cb91787c5fceb5eab7c8b5011f472c..4a59e0054ef46e3537ac15cea4f2702c7ddb9eee` and relevant optimizer code, tests, examples, and documentation.</code>
- <code>Initial `poetry run python` environment probe failed because PyTorch was absent; ran `poetry install` and retried successfully.</code>
- <code>`poetry run pytest -q tests/optim/test_ga.py` on CPU and available Apple MPS.</code>
- <code>Executed an ordinary `torch.nn.Linear` GA workflow covering float64 CPU, float32 MPS, initialization and later results, stored best tensors, `restore_best()`, fresh-state `reset_counters()`, integer seed reproducibility and divergence, global RNG isolation, fresh `None` streams, and comparison with RHC and SA.</code>
- `poetry run pytest`
- `git diff --check 9c28d45f31cb91787c5fceb5eab7c8b5011f472c..4a59e0054ef46e3537ac15cea4f2702c7ddb9eee`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
