### PR TITLE
fix(optim): schedule RHC restarts by proposed steps

### DIFF
--- a/docs/general_usage_guide.md
+++ b/docs/general_usage_guide.md
@@ -89,10 +89,14 @@ Parameters:
 
 - `step_size`: scale of the random parameter perturbation.
 - `restarts`: maximum number of random restarts.
-- `restart_interval`: number of proposed steps between restarts. Use `None` to disable.
+- `restart_interval`: number of proposed steps between restarts, regardless of whether
+  the proposal at the interval boundary is accepted or rejected. Use `None` to
+  disable.
 - `random_state`: optional seed for reproducible random proposals.
 
 RHC accepts candidate moves only when they do not increase the loss.
+After a restart, the next call evaluates the randomized parameters without counting
+another proposed step.
 
 ---
 

--- a/pyperch/optim/rhc.py
+++ b/pyperch/optim/rhc.py
@@ -83,16 +83,18 @@ class RHC(RandomizedOptimizer):
             self._current_loss = candidate_loss
             self.accepted_steps += 1
             self._save_best_if_needed(candidate_loss)
-            return candidate_loss_tensor
+            result = candidate_loss_tensor
+        else:
+            self._restore_params(old_params)
+            self.rejected_steps += 1
+            result = torch.tensor(
+                old_loss,
+                dtype=candidate_loss_tensor.dtype,
+                device=candidate_loss_tensor.device,
+            )
 
-        self._restore_params(old_params)
-        self.rejected_steps += 1
         self._maybe_restart()
-        return torch.tensor(
-            old_loss,
-            dtype=candidate_loss_tensor.dtype,
-            device=candidate_loss_tensor.device,
-        )
+        return result
 
     def _evaluate(self, closure: Callable[[], torch.Tensor]) -> torch.Tensor:
         """Run the closure and count one objective evaluation."""

--- a/tests/optim/test_rhc.py
+++ b/tests/optim/test_rhc.py
@@ -18,6 +18,29 @@ def make_regression_data(n=64, d=3):
     return X, y
 
 
+def make_scalar_optimizer(*, seed, restarts, restart_interval):
+    torch.manual_seed(0)
+    model = nn.Linear(1, 1, bias=False)
+    with torch.no_grad():
+        model.weight.zero_()
+
+    optimizer = RHC(
+        model.parameters(),
+        step_size=1.0,
+        restarts=restarts,
+        restart_interval=restart_interval,
+        random_state=seed,
+    )
+    X = torch.ones(1, 1)
+    y = torch.full((1, 1), -100.0)
+    criterion = nn.MSELoss()
+
+    def closure():
+        return criterion(model(X), y)
+
+    return optimizer, closure
+
+
 def test_rhc_classification_improves_loss():
     torch.manual_seed(42)
 
@@ -119,3 +142,122 @@ def test_rhc_reset_counters():
     assert optimizer.accepted_steps == 0
     assert optimizer.rejected_steps == 0
     assert optimizer.best_loss is None
+
+
+def test_rhc_accepted_boundary_proposal_restarts():
+    optimizer, closure = make_scalar_optimizer(seed=10, restarts=1, restart_interval=1)
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+
+    assert optimizer.accepted_steps == 1
+    assert optimizer.rejected_steps == 0
+    assert optimizer.completed_restarts == 1
+
+
+def test_rhc_rejected_boundary_proposal_restarts():
+    optimizer, closure = make_scalar_optimizer(seed=3, restarts=1, restart_interval=1)
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+
+    assert optimizer.accepted_steps == 0
+    assert optimizer.rejected_steps == 1
+    assert optimizer.completed_restarts == 1
+
+
+def _assert_proposal_outcome(optimizer, *, accepted, rejected):
+    assert optimizer.proposed_steps == 1
+    assert optimizer.accepted_steps == accepted
+    assert optimizer.rejected_steps == rejected
+    assert optimizer.completed_restarts == 0
+
+
+def test_rhc_non_boundary_proposals_do_not_restart():
+    accepted_optimizer, accepted_closure = make_scalar_optimizer(
+        seed=10, restarts=1, restart_interval=2
+    )
+    rejected_optimizer, rejected_closure = make_scalar_optimizer(
+        seed=3, restarts=1, restart_interval=2
+    )
+
+    accepted_optimizer.step(accepted_closure)
+    accepted_optimizer.step(accepted_closure)
+    rejected_optimizer.step(rejected_closure)
+    rejected_optimizer.step(rejected_closure)
+
+    _assert_proposal_outcome(accepted_optimizer, accepted=1, rejected=0)
+    _assert_proposal_outcome(rejected_optimizer, accepted=0, rejected=1)
+
+
+def test_rhc_mixed_outcomes_restart_at_proposal_multiples_until_exhausted():
+    optimizer, closure = make_scalar_optimizer(seed=13, restarts=2, restart_interval=2)
+
+    optimizer.step(closure)
+    restart_proposals = []
+    outcomes = []
+    while optimizer.proposed_steps < 6:
+        previous_restarts = optimizer.completed_restarts
+        previous_accepted = optimizer.accepted_steps
+        previous_rejected = optimizer.rejected_steps
+        optimizer.step(closure)
+        if optimizer.completed_restarts > previous_restarts:
+            restart_proposals.append(optimizer.proposed_steps)
+        if optimizer.accepted_steps > previous_accepted:
+            outcomes.append("accepted")
+        elif optimizer.rejected_steps > previous_rejected:
+            outcomes.append("rejected")
+
+    assert "accepted" in outcomes
+    assert "rejected" in outcomes
+    assert restart_proposals == [2, 4]
+    assert optimizer.completed_restarts == 2
+    assert optimizer.proposed_steps == 6
+    assert optimizer.accepted_steps + optimizer.rejected_steps == 6
+
+
+def test_rhc_post_restart_evaluation_does_not_count_as_proposal():
+    optimizer, closure = make_scalar_optimizer(seed=10, restarts=1, restart_interval=1)
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+    counters_after_restart = (
+        optimizer.function_evals,
+        optimizer.proposed_steps,
+        optimizer.accepted_steps,
+        optimizer.rejected_steps,
+    )
+    optimizer.step(closure)
+
+    assert counters_after_restart == (2, 1, 1, 0)
+    assert optimizer.function_evals == 3
+    assert optimizer.proposed_steps == 1
+    assert optimizer.accepted_steps == 1
+    assert optimizer.rejected_steps == 0
+    assert optimizer.completed_restarts == 1
+
+
+def _assert_restarts_disabled(optimizer):
+    assert optimizer.completed_restarts == 0
+    assert optimizer.proposed_steps == 4
+    assert optimizer.accepted_steps + optimizer.rejected_steps == 4
+
+
+def test_rhc_disabled_restart_configurations_remain_disabled():
+    no_interval_optimizer, no_interval_closure = make_scalar_optimizer(
+        seed=13, restarts=2, restart_interval=None
+    )
+    no_budget_optimizer, no_budget_closure = make_scalar_optimizer(
+        seed=13, restarts=0, restart_interval=1
+    )
+
+    for optimizer, closure in (
+        (no_interval_optimizer, no_interval_closure),
+        (no_budget_optimizer, no_budget_closure),
+    ):
+        optimizer.step(closure)
+        for _ in range(4):
+            optimizer.step(closure)
+
+    _assert_restarts_disabled(no_interval_optimizer)
+    _assert_restarts_disabled(no_budget_optimizer)


### PR DESCRIPTION
## Intent

Fix PyPerch RHC restart scheduling so configured restart intervals count proposed steps regardless of whether the boundary proposal is accepted or rejected. Preserve restart budget exhaustion, randomization, best-state preservation, closure ownership, constructor defaults, existing counter meanings, and disabled restart behavior. The next call after a restart must evaluate the randomized state without counting another proposal. Keep reset_counters restart phase, retained completed_restarts, and restart-budget semantics unchanged and out of scope. Add observable regression coverage through a normal PyTorch model, native parameter iterable, loss closure, and RHC.step loop, plus only the public guide clarification required by this contract. Push and open a pull request after the full pipeline passes, but do not merge it.

## What Changed

- Schedule RHC restarts after every interval-boundary proposal, whether accepted or rejected, while preserving restart budgets and post-restart evaluation behavior.
- Add PyTorch regression coverage for accepted, rejected, non-boundary, exhausted-budget, and disabled-restart scenarios.
- Clarify proposal-based restart timing and post-restart evaluation semantics in the usage guide.

## Risk Assessment

✅ Low: The change is narrowly scoped and correctly applies restart scheduling after every proposed step while preserving restart budgets, counters, randomized-state evaluation, best-state handling, defaults, and disabled restart behavior.

## Testing

After repairing the fresh worktree environment from the lockfile, the focused RHC tests and complete pytest suite passed; a captured native-PyTorch model, parameter iterable, closure, and `RHC.step` loop directly demonstrated accepted and rejected boundary restarts, randomized-state evaluation without another proposal, best-state restoration, closure ownership, constructor defaults, restart-budget exhaustion, and disabled restart behavior.

<details>
<summary>Evidence: RHC restart end-to-end transcript</summary>

```text
^DRHC public API end-to-end restart trace
constructor: (params, step_size: 'float' = 0.1, restarts: 'int' = 0, restart_interval: 'int | None' = None, random_state: 'int | None' = None)
accepted boundary: initial_loss=10000.0000, returned_loss=9880.0830, randomized_weight=-1.012210
  at restart (evals, proposals, accepted, rejected, restarts): (2, 1, 1, 0, 1)
  next call  (evals, proposals, accepted, rejected, restarts): (3, 1, 1, 0, 1)
  restore_best loss=9798.5830, recorded_best=9798.5830
rejected boundary: initial_loss=10000.0000, returned_loss=10000.0000, randomized_weight=0.174833
  at restart (evals, proposals, accepted, rejected, restarts): (2, 1, 0, 1, 1)
  next call  (evals, proposals, accepted, rejected, restarts): (3, 1, 0, 1, 1)
mixed outcomes: ['accepted', 'accepted', 'rejected', 'rejected', 'accepted', 'rejected']
restart proposal counts: [2, 4]
after budget exhausted (proposals, accepted, rejected, restarts): (6, 3, 3, 2)
disabled interval=None: proposals=4, restarts=0
disabled restarts=0: proposals=4, restarts=0
RESULT: all end-to-end restart contract checks passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Reviewed `git diff e99ce06fee01fa0c96f85c4c48c7515df58b78b1..65f46c8cad3198eca70840f0ca30c642f21d71af` against the supplied acceptance criteria.</code>
- <code>`poetry run pytest tests/optim/test_rhc.py -q` (initial collection failed because the fresh local environment lacked `torch`)</code>
- <code>`poetry install` (installed locked dependencies into the worktree-local `.venv`)</code>
- `poetry run pytest tests/optim/test_rhc.py -q`
- `script -q /var/folders/54/hb_211gx6_5gwww9jh2xz3gc0000gn/T/no-mistakes-evidence/01M0M3MRJNTZ5PYS9663Z5C914/rhc_restart_end_to_end.txt poetry run python -c '<end-to-end RHC public API scenario>'`
- `poetry run pytest`
- <code>Removed the generated `.venv`, `.pytest_cache`, and Python bytecode caches, then verified `git status --short` was clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
