### PR TITLE
fix(search): correct Optuna search and model evaluation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            poetry install
+            poetry install --extras optuna
 
       - save_cache:
           paths:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,14 @@ losses, and training loops. Prefer focused changes over new abstraction layers.
 
 ## Before changing code
 
+Clone the repository and install the development dependencies with Optuna support:
+
+```bash
+git clone https://github.com/jlm429/pyperch.git
+cd pyperch
+poetry install --extras optuna
+```
+
 - Read `AGENTS.md` and the nearest implementation, tests, example, and guide.
 - Check the worktree for unrelated changes and keep the patch reviewable.
 - Reproduce bugs through a normal end-to-end PyTorch usage path before fixing them.
@@ -14,9 +22,8 @@ losses, and training loops. Prefer focused changes over new abstraction layers.
 - Avoid new dependencies unless the project requirement clearly needs one.
 
 The supported Python and PyTorch ranges and dependency groups are declared in
-`pyproject.toml`. `poetry install --extras optuna` installs the runtime and
-development dependency groups plus the optional search dependency. CircleCI installs
-that dependency set and runs on Python 3.12.
+`pyproject.toml`. The [CircleCI configuration](.circleci/config.yml) owns the exact
+CI environment.
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,9 @@ losses, and training loops. Prefer focused changes over new abstraction layers.
 - Avoid new dependencies unless the project requirement clearly needs one.
 
 The supported Python and PyTorch ranges and dependency groups are declared in
-`pyproject.toml`. `poetry install` installs the runtime and development dependency
-groups. CircleCI installs that dependency set and runs on Python 3.12.
+`pyproject.toml`. `poetry install --extras optuna` installs the runtime and
+development dependency groups plus the optional search dependency. CircleCI installs
+that dependency set and runs on Python 3.12.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -44,18 +44,7 @@ poetry add "pyperch[optuna]"
 
 ## Development Setup
 
-Clone the repository:
-
-```bash
-git clone https://github.com/jlm429/pyperch.git
-cd pyperch
-```
-
-Install development dependencies:
-
-```bash
-poetry install --extras optuna
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for source-checkout setup and validation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ or with Poetry:
 poetry add pyperch
 ```
 
+Optuna search is an optional extra. Install it from PyPI with:
+
+```bash
+pip install "pyperch[optuna]"
+```
+
+or with Poetry:
+
+```bash
+poetry add "pyperch[optuna]"
+```
+
 ---
 
 ## Development Setup
@@ -42,7 +54,7 @@ cd pyperch
 Install development dependencies:
 
 ```bash
-poetry install
+poetry install --extras optuna
 ```
 
 ---

--- a/docs/search.md
+++ b/docs/search.md
@@ -14,17 +14,9 @@ raises an `ImportError` with the required install command.
 
 # Installation
 
-Install PyPerch with Optuna support:
-
-```bash
-pip install "pyperch[optuna]"
-```
-
-For a source checkout managed with Poetry, install the extra with:
-
-```bash
-poetry install --extras optuna
-```
+Install the optional Optuna extra as described in the
+[README installation guide](../README.md#installation). For a source checkout,
+follow the [contributor setup](../CONTRIBUTING.md#before-changing-code).
 
 ---
 
@@ -185,11 +177,5 @@ Supported directions:
 Examples are designed to be runnable in a standard Python environment, including
 Google Colab. In most cases, you should be able to install PyPerch, then copy and
 run the example code.
-
-Search requires the optional Optuna extra:
-
-```bash
-pip install "pyperch[optuna]"
-```
 
 [optuna_search_example.py](../examples/search/optuna_search_example.py)

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,19 +1,29 @@
 # Optuna Search Usage Guide
 
-The `pyperch.search` package provides a lightweight wrapper for Optuna-based hyperparameter search.
+The `pyperch.search` package provides an optional, lightweight wrapper for
+Optuna-based hyperparameter search.
 
-This layer is intended for quick experimentation, tuning, demos, and research workflows while remaining fully compatible with standard PyTorch training patterns.
+This layer is intended for quick experimentation, tuning, demos, and research
+workflows while remaining fully compatible with standard PyTorch training patterns.
 PyPerch search utilities do not abstract or replace PyTorch training loops.
-Optuna is installed as a PyPerch dependency. Calling `OptunaSearch.search(...)` without Optuna available raises an `ImportError`.
+Optuna is an optional dependency. Importing PyPerch and using its optimizers does
+not require Optuna. Calling `OptunaSearch.search(...)` without Optuna available
+raises an `ImportError` with the required install command.
 
 ---
 
 # Installation
 
-Install PyPerch and its dependencies:
+Install PyPerch with Optuna support:
 
 ```bash
-pip install pyperch
+pip install "pyperch[optuna]"
+```
+
+For a source checkout managed with Poetry, install the extra with:
+
+```bash
+poetry install --extras optuna
 ```
 
 ---
@@ -67,6 +77,8 @@ def objective(params, trial):
             return loss_fn(output, y_train)
 
         optimizer.step(closure)
+
+    optimizer.restore_best()
 
     with torch.no_grad():
         valid_loss = loss_fn(model(X_valid), y_valid).item()
@@ -139,6 +151,13 @@ optimizer = SA(
 
 `search.search(...)` returns the underlying Optuna `Study`.
 
+The study retains trial hyperparameters and objective values, not PyTorch model
+weights. `study.best_params` is the hyperparameter dictionary from the best trial.
+It does not guarantee that a model left in memory has that trial's weights or even
+that an optimizer's current weights are its best observed weights. Explicitly
+retrain with `study.best_params`, call `optimizer.restore_best()`, and then evaluate
+the restored model.
+
 Common attributes:
 
 ```python
@@ -163,8 +182,14 @@ Supported directions:
 
 # Examples
 
-Examples are designed to be runnable in a standard Python environment, including Google Colab. In most cases, you should be able to pip install PyPerch then copy/paste the example code and run it.
+Examples are designed to be runnable in a standard Python environment, including
+Google Colab. In most cases, you should be able to install PyPerch, then copy and
+run the example code.
 
-Search requires Optuna, which is installed with PyPerch.
+Search requires the optional Optuna extra:
+
+```bash
+pip install "pyperch[optuna]"
+```
 
 [optuna_search_example.py](../examples/search/optuna_search_example.py)

--- a/examples/search/optuna_search_example.py
+++ b/examples/search/optuna_search_example.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import optuna
 import torch
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
@@ -77,6 +78,7 @@ search = OptunaSearch(
         "min_temperature": ("float", 0.001, 0.01, True),
     },
     direction="minimize",
+    study_kwargs={"sampler": optuna.samplers.TPESampler(seed=seed)},
 )
 
 
@@ -105,6 +107,7 @@ def objective(params, trial):
         temperature=params["temperature"],
         cooling=params["cooling"],
         min_temperature=params["min_temperature"],
+        random_state=seed,
     )
 
     for _ in range(3000):
@@ -114,6 +117,8 @@ def objective(params, trial):
             return loss_fn(output, y_train)
 
         optimizer.step(closure)
+
+    optimizer.restore_best()
 
     with torch.no_grad():
         valid_loss = loss_fn(model(X_valid), y_valid).item()
@@ -153,6 +158,7 @@ best_optimizer = SA(
     temperature=best_params["temperature"],
     cooling=best_params["cooling"],
     min_temperature=best_params["min_temperature"],
+    random_state=seed,
 )
 
 train_losses = []
@@ -170,6 +176,18 @@ for _ in range(3000):
     with torch.no_grad():
         valid_loss = loss_fn(best_model(X_valid), y_valid).item()
         valid_losses.append(valid_loss)
+
+best_optimizer.restore_best()
+
+with torch.no_grad():
+    best_train_loss = loss_fn(best_model(X_train), y_train).item()
+    best_valid_loss = loss_fn(best_model(X_valid), y_valid).item()
+
+print("\nRetrained best training loss:")
+print(best_train_loss)
+
+print("\nRetrained best validation loss:")
+print(best_valid_loss)
 
 
 # ------------------------------------------------------------

--- a/examples/search/optuna_search_example.py
+++ b/examples/search/optuna_search_example.py
@@ -94,7 +94,8 @@ search = OptunaSearch(
 # 1. Create a fresh model
 # 2. Create the optimizer using sampled params
 # 3. Train the model
-# 4. Return a scalar validation metric
+# 4. Restore the optimizer's best model weights
+# 5. Evaluate and return a scalar validation metric
 # ------------------------------------------------------------
 def objective(params, trial):
     torch.manual_seed(seed)

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,9 +4,10 @@
 name = "alembic"
 version = "1.18.4"
 description = "A database migration tool for SQLAlchemy."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a"},
     {file = "alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc"},
@@ -32,15 +33,16 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "extra == \"optuna\" and (sys_platform == \"win32\" or platform_system == \"Windows\")", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "colorlog"
 version = "6.10.1"
 description = "Add colours to the output of Python's logging module."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c"},
     {file = "colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321"},
@@ -392,10 +394,10 @@ tqdm = ["tqdm"]
 name = "greenlet"
 version = "3.5.1"
 description = "Lightweight in-process concurrent programming"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+markers = "extra == \"optuna\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.5.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7eacb17a9d41538a2bc4912eba5ef13823c83cb69e4d141d0813debe7163187f"},
     {file = "greenlet-3.5.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5cc9606aa5f4e0bde0d3bd502b44f743864c3ffa5cfa1011b1e30f5aa02366f"},
@@ -655,9 +657,10 @@ files = [
 name = "mako"
 version = "1.3.12"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
     {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
@@ -1180,9 +1183,10 @@ files = [
 name = "optuna"
 version = "4.8.0"
 description = "A hyperparameter optimization framework"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "optuna-4.8.0-py3-none-any.whl", hash = "sha256:c57a7682679c36bfc9bca0da430698179e513874074b71bebedb0334964ab930"},
     {file = "optuna-4.8.0.tar.gz", hash = "sha256:6f7043e9f8ecb5e607af86a7eb00fb5ec2be26c3b08c201209a73d36aff37a38"},
@@ -1214,6 +1218,7 @@ files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
+markers = {main = "extra == \"optuna\""}
 
 [[package]]
 name = "pillow"
@@ -1413,9 +1418,10 @@ six = ">=1.5"
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -1677,9 +1683,10 @@ files = [
 name = "sqlalchemy"
 version = "2.0.49"
 description = "Database Abstraction Library"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "sqlalchemy-2.0.49-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:42e8804962f9e6f4be2cbaedc0c3718f08f60a16910fa3d86da5a1e3b1bfe60f"},
     {file = "sqlalchemy-2.0.49-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc992c6ed024c8c3c592c5fc9846a03dd68a425674900c70122c77ea16c5fb0b"},
@@ -1812,7 +1819,6 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
     {file = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"},
@@ -1862,6 +1868,7 @@ files = [
     {file = "tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"},
     {file = "tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"},
 ]
+markers = {main = "extra == \"optuna\" and python_version == \"3.10\"", dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "torch"
@@ -1927,9 +1934,10 @@ pyyaml = ["pyyaml"]
 name = "tqdm"
 version = "4.67.3"
 description = "Fast, Extensible Progress Meter"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"optuna\""
 files = [
     {file = "tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"},
     {file = "tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb"},
@@ -1994,4 +2002,4 @@ optuna = ["optuna"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "ad2b03cda3c8f44817b69063e7c3faf6cb4dce4895d2cdbbd30c768e8c35f505"
+content-hash = "15d968f51a3c2163adc7923e9038d65f3237509f5b7bbc96edb1bb439b31b048"

--- a/pyperch/search/optuna.py
+++ b/pyperch/search/optuna.py
@@ -50,7 +50,7 @@ class OptunaSearch:
         except ImportError as exc:
             raise ImportError(
                 "Optuna support requires the optional dependency. "
-                "Install with: poetry install --extras optuna"
+                "Install with: pip install 'pyperch[optuna]'"
             ) from exc
 
         study = optuna.create_study(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Repository = "https://github.com/jlm429/pyperch"
 python = ">=3.10,<3.14"
 torch = ">=2.1,<3.0"
 numpy = ">=1.24"
-optuna = "==4.8.0"
+optuna = { version = "^4.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -1,0 +1,145 @@
+import builtins
+import subprocess
+import sys
+
+import pytest
+
+from pyperch.search import OptunaSearch
+
+
+class RecordingTrial:
+    def __init__(self):
+        self.calls = []
+
+    def suggest_float(self, name, low, high, *, log):
+        self.calls.append(("float", name, low, high, log))
+        return high
+
+    def suggest_int(self, name, low, high, *, step):
+        self.calls.append(("int", name, low, high, step))
+        return high
+
+    def suggest_categorical(self, name, choices):
+        self.calls.append(("categorical", name, choices))
+        return choices[-1]
+
+
+def test_suggest_params_supports_public_parameter_specs():
+    search = OptunaSearch(
+        {
+            "plain_float": ("float", 0.1, 0.9),
+            "log_float": ("float", 0.01, 1.0, True),
+            "plain_int": ("int", 1, 5),
+            "stepped_int": ("int", 2, 8, 2),
+            "choice": ("categorical", ["rhc", "sa"]),
+        }
+    )
+    trial = RecordingTrial()
+
+    params = search.suggest_params(trial)
+
+    assert params == {
+        "plain_float": 0.9,
+        "log_float": 1.0,
+        "plain_int": 5,
+        "stepped_int": 8,
+        "choice": "sa",
+    }
+    assert trial.calls == [
+        ("float", "plain_float", 0.1, 0.9, False),
+        ("float", "log_float", 0.01, 1.0, True),
+        ("int", "plain_int", 1, 5, 1),
+        ("int", "stepped_int", 2, 8, 2),
+        ("categorical", "choice", ["rhc", "sa"]),
+    ]
+
+
+def test_suggest_params_rejects_unsupported_parameter_type():
+    search = OptunaSearch({"schedule": ("callable", lambda step: step)})
+
+    with pytest.raises(ValueError, match="Unsupported parameter type: callable"):
+        search.suggest_params(RecordingTrial())
+
+
+def test_search_returns_native_study_and_forwards_trial_and_options():
+    optuna = pytest.importorskip("optuna")
+    callbacks = []
+    search = OptunaSearch(
+        {"value": ("categorical", [3, 1, 2])},
+        direction="minimize",
+        study_kwargs={
+            "study_name": "direct-search-test",
+            "sampler": optuna.samplers.GridSampler(
+                {"value": [3, 1, 2]},
+                seed=7,
+            ),
+        },
+    )
+
+    def objective(params, trial):
+        assert params == trial.params
+        assert isinstance(trial, optuna.trial.Trial)
+        return float(params["value"])
+
+    study = search.search(
+        objective,
+        n_trials=3,
+        callbacks=[lambda study, trial: callbacks.append(trial.number)],
+    )
+
+    assert isinstance(study, optuna.study.Study)
+    assert study.study_name == "direct-search-test"
+    assert study.direction is optuna.study.StudyDirection.MINIMIZE
+    assert study.best_params == {"value": 1}
+    assert study.best_value == 1.0
+    assert study.best_trial.number == 1
+    assert study.best_trial.number != study.trials[-1].number
+    assert sorted(trial.params["value"] for trial in study.trials) == [1, 2, 3]
+    assert callbacks == [0, 1, 2]
+
+
+def test_core_and_search_import_without_optuna():
+    script = """
+import builtins
+
+import torch
+
+original_import = builtins.__import__
+
+
+def import_without_optuna(name, *args, **kwargs):
+    if name == "optuna" or name.startswith("optuna."):
+        raise ImportError("Optuna intentionally unavailable")
+    return original_import(name, *args, **kwargs)
+
+
+builtins.__import__ = import_without_optuna
+
+import pyperch
+from pyperch.optim import RHC
+from pyperch.search import OptunaSearch
+
+parameter = torch.nn.Parameter(torch.tensor([1.0]))
+optimizer = RHC([parameter], step_size=0.1, random_state=7)
+optimizer.step(lambda: parameter.square().sum())
+
+assert pyperch.RHC is RHC
+assert OptunaSearch({"value": ("int", 1, 1)}).param_space
+"""
+
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_search_without_optuna_reports_optional_install_command(monkeypatch):
+    original_import = builtins.__import__
+
+    def import_without_optuna(name, *args, **kwargs):
+        if name == "optuna":
+            raise ImportError("Optuna intentionally unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_optuna)
+    search = OptunaSearch({"value": ("int", 1, 1)})
+
+    with pytest.raises(ImportError, match=r"pip install 'pyperch\[optuna\]'"):
+        search.search(lambda params, trial: 0.0, n_trials=1)


### PR DESCRIPTION
## Intent

Investigate and correct PyPerch search and Optuna correctness and consistency only. Ensure the Optuna example explicitly restores and evaluates optimizer-best model weights instead of relying on current or last-trial state, replace the empty direct search test surface with deterministic network-free coverage of public OptunaSearch behavior and important invariants, and align packaging, installation documentation, imports, CI, and history around the evidence-supported optional Optuna contract. Preserve native PyTorch and visible Optuna behavior, keep non-Optuna functionality usable without the extra, avoid unrelated refactors and em dashes, validate targeted and full suites, push a focused feature branch, open a PR, and stop at checks-passed without merging.

## What Changed

- Make Optuna an optional package extra, preserve core PyPerch imports without it, and provide an actionable installation error when search is invoked without the extra.
- Correct the Optuna example and guidance to restore optimizer-best weights before evaluation, seed randomized behavior, and explicitly retrain using the study’s best hyperparameters.
- Add deterministic coverage for parameter suggestions, native Optuna study behavior, option forwarding, best-trial selection, and optional-dependency invariants, while aligning CI and contributor setup with the Optuna extra.

## Risk Assessment

✅ Low: The focused changes satisfy the stated Optuna correctness and optional-dependency requirements without introducing a substantiated material defect.

## Testing

After repairing the initially empty local Poetry environment, focused and full tests passed; the seeded public example completed all 20 native Optuna trials, selected a non-final best trial, explicitly restored and evaluated optimizer-best weights with retrained validation loss matching the study best value, and produced a rendered curve, while built-wheel metadata confirmed Optuna is optional. Cleanup succeeded, but no remote branch, open PR, or CI result exists for the target commit.

<details>
<summary>Evidence: End-to-end Optuna example transcript</summary>

```text
[I 2026-08-22 03:13:10,136] A new study created in memory with name: no-name-ff0c8124-0208-448f-adec-51806ca12fe9
[I 2026-08-22 03:13:10,608] Trial 0 finished with value: 0.2572130560874939 and parameters: {'step_size': 0.043284502212938815, 'temperature': 1.7254716573280358, 'cooling': 0.9724674002393291, 'min_temperature': 0.003968793330444372}. Best is trial 0 with value: 0.2572130560874939.
[I 2026-08-22 03:13:10,808] Trial 1 finished with value: 0.4199356734752655 and parameters: {'step_size': 0.018410729205738687, 'temperature': 0.15957084694148355, 'cooling': 0.9057502776046518, 'min_temperature': 0.007348118405270454}. Best is trial 0 with value: 0.2572130560874939.
[I 2026-08-22 03:13:10,995] Trial 2 finished with value: 0.31175166368484497 and parameters: {'step_size': 0.10502105436744279, 'temperature': 0.8341106432362086, 'cooling': 0.9020378649352845, 'min_temperature': 0.009330606024425666}. Best is trial 0 with value: 0.2572130560874939.
[I 2026-08-22 03:13:11,184] Trial 3 finished with value: 0.2077631950378418 and parameters: {'step_size': 0.2595942550311263, 'temperature': 0.18891200276189393, 'cooling': 0.918000671753503, 'min_temperature': 0.0015254729458052604}. Best is trial 3 with value: 0.2077631950378418.
[I 2026-08-22 03:13:11,371] Trial 4 finished with value: 0.2326616495847702 and parameters: {'step_size': 0.032877474139911184, 'temperature': 0.4816414530907083, 'cooling': 0.9427625568455694, 'min_temperature': 0.001955370866274525}. Best is trial 3 with value: 0.2077631950378418.
[I 2026-08-22 03:13:11,559] Trial 5 finished with value: 0.2426154762506485 and parameters: {'step_size': 0.10952662748632554, 'temperature': 0.1518747922672247, 'cooling': 0.9289223202049867, 'min_temperature': 0.0023246728489504354}. Best is trial 3 with value: 0.2077631950378418.
[I 2026-08-22 03:13:11,747] Trial 6 finished with value: 0.16209255158901215 and parameters: {'step_size': 0.05954553793888992, 'temperature': 1.0508421338691765, 'cooling': 0.9197677044336776, 'min_temperature': 0.0032676417657817635}. Best is trial 6 with value: 0.16209255158901215.
[I 2026-08-22 03:13:11,934] Trial 7 finished with value: 0.14653176069259644 and parameters: {'step_size': 0.10150667045928574, 'temperature': 0.11492999300221414, 'cooling': 0.9601469403382424, 'min_temperature': 0.0014808945119975188}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:12,117] Trial 8 finished with value: 0.5577326416969299 and parameters: {'step_size': 0.012897950480855536, 'temperature': 1.7160445029754816, 'cooling': 0.9955975712743814, 'min_temperature': 0.006432759992849893}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:12,303] Trial 9 finished with value: 0.22717395424842834 and parameters: {'step_size': 0.032925293631105246, 'temperature': 0.13399060561509787, 'cooling': 0.9677390696247036, 'min_temperature': 0.0027551959649510763}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:12,492] Trial 10 finished with value: 0.20564578473567963 and parameters: {'step_size': 0.4153034526700882, 'temperature': 0.2973175967079414, 'cooling': 0.9573661785475056, 'min_temperature': 0.0010422259339479673}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:12,678] Trial 11 finished with value: 0.4160657823085785 and parameters: {'step_size': 0.16407851589111905, 'temperature': 0.7907371573909026, 'cooling': 0.9408371937404453, 'min_temperature': 0.00408254061654954}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:12,864] Trial 12 finished with value: 0.1897239089012146 and parameters: {'step_size': 0.06924458725715478, 'temperature': 0.9134562731480679, 'cooling': 0.9850337298111179, 'min_temperature': 0.0010436058798523721}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:13,049] Trial 13 finished with value: 0.2794046700000763 and parameters: {'step_size': 0.06102525235303387, 'temperature': 0.3673757945485906, 'cooling': 0.9259648665025221, 'min_temperature': 0.0038886576385001293}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:13,237] Trial 14 finished with value: 0.1840994954109192 and parameters: {'step_size': 0.1486288561779149, 'temperature': 0.1023705174627128, 'cooling': 0.9560650594232445, 'min_temperature': 0.0016382177817601841}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:13,424] Trial 15 finished with value: 0.2327151745557785 and parameters: {'step_size': 0.25720146949981815, 'temperature': 0.5406544777671927, 'cooling': 0.9358969592497078, 'min_temperature': 0.0053789577693905185}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:13,610] Trial 16 finished with value: 0.3342823088169098 and parameters: {'step_size': 0.020676982530745583, 'temperature': 1.0408069688677413, 'cooling': 0.9148323978760033, 'min_temperature': 0.00291149419826145}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:13,798] Trial 17 finished with value: 0.19370724260807037 and parameters: {'step_size': 0.04961311942997737, 'temperature': 0.2485683766680167, 'cooling': 0.970171222725651, 'min_temperature': 0.0014008379501512706}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:13,985] Trial 18 finished with value: 0.19164900481700897 and parameters: {'step_size': 0.09792316462349702, 'temperature': 1.2659088783993624, 'cooling': 0.9528471971660663, 'min_temperature': 0.0022084235770155353}. Best is trial 7 with value: 0.14653176069259644.
[I 2026-08-22 03:13:14,171] Trial 19 finished with value: 0.32531628012657166 and parameters: {'step_size': 0.1952819583677863, 'temperature': 0.6269181754429076, 'cooling': 0.9826052428591093, 'min_temperature': 0.004782779921022751}. Best is trial 7 with value: 0.14653176069259644.
/Users/jlm429/.no-mistakes/worktrees/9fdb94ed74da/01M0M4W0FTYZ964XN5H8KP19AZ/examples/search/optuna_search_example.py:203: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
  plt.show()
Best parameters:
{'step_size': 0.10150667045928574, 'temperature': 0.11492999300221414, 'cooling': 0.9601469403382424, 'min_temperature': 0.0014808945119975188}

Best validation loss:
0.14653176069259644

Retrained best training loss:
0.14724339544773102

Retrained best validation loss:
0.14653176069259644
```
</details>
- Evidence: Rendered best-parameter learning curve (local file: <code>/var/folders/54/hb_211gx6_5gwww9jh2xz3gc0000gn/T/no-mistakes-evidence/01M0M4W0FTYZ964XN5H8KP19AZ/optuna-search-learning-curve.png</code>)
<details>
<summary>Evidence: Built-wheel optional dependency metadata</summary>

<code>Name: pyperch&#10;Version: 0.3.1&#10;Provides-Extra: optuna&#10;Requires-Dist: numpy (&gt;=1.24)&#10;Requires-Dist: optuna (&gt;=4.0,&lt;5.0) ; extra == &#34;optuna&#34;&#10;Requires-Dist: torch (&gt;=2.1,&lt;3.0)</code>

```text
Name: pyperch
Version: 0.3.1
Provides-Extra: optuna
Requires-Dist: numpy (>=1.24)
Requires-Dist: optuna (>=4.0,<5.0) ; extra == "optuna"
Requires-Dist: torch (>=2.1,<3.0)
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The required delivery state cannot be demonstrated: GitHub reports no pull request for head `fm/pyperch-search-optuna-correctness`, and no remote branch contains target commit `a5aca9cd58833ea60216349258591791c7a34d82`. The inspected PR #18 is an unrelated merged change. Push this focused branch, open an unmerged PR, and obtain passing checks.
- <code>`git diff --stat 6a233c41594049f230b3f01103f5d96035805c68..a5aca9cd58833ea60216349258591791c7a34d82` and related scope/history inspection</code>
- <code>`poetry run pytest tests/search/test_search.py -q` (initial setup failure because the new local environment lacked dependencies)</code>
- `poetry install --extras optuna`
- `poetry run pytest tests/search/test_search.py -q`
- `poetry run pytest`
- `MPLBACKEND=Agg poetry run python examples/search/optuna_search_example.py > …/optuna-search-example.log 2>&1`
- <code>`MPLBACKEND=Agg poetry run python -c &#34;…runpy.run_path(&#39;examples/search/optuna_search_example.py&#39;…)…&#34;` to render the learning curve</code>
- `poetry build -f wheel -o …/package`
- `unzip -p …/pyperch-0.3.1-py3-none-any.whl '*/METADATA' | rg '^(Name|Version|Requires-Dist|Provides-Extra):'`
- `gh-axi pr list --state all --head fm/pyperch-search-optuna-correctness --limit 10`
- `git branch -r --contains a5aca9cd58833ea60216349258591791c7a34d82`
- <code>`gh-axi pr view 18 --full` and `gh-axi pr checks 18`</code>
- <code>Removed the test-created `.venv`, pytest cache, and Python bytecode directories; `git status --short --untracked-files=all` was empty afterward.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
