### PR TITLE
build: migrate package metadata to PEP 621

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2002,4 +2002,4 @@ optuna = ["optuna"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "15d968f51a3c2163adc7923e9038d65f3237509f5b7bbc96edb1bb439b31b048"
+content-hash = "fad0b80470b5797113884a8fc6d91b082cb5992de0d80b101dc47b23ec5f73cd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
-[tool.poetry]
+[project]
 name = "pyperch"
 version = "0.3.1"
 description = "PyTorch-native randomized optimization algorithms."
-authors = ["John Mansfield"]
+authors = [{ name = "John Mansfield" }]
 readme = "README.md"
 license = "MIT"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "torch>=2.1,<3.0",
+    "numpy>=1.24",
+]
 keywords = [
     "pytorch",
     "optimization",
@@ -12,17 +17,15 @@ keywords = [
     "randomized-optimization",
 ]
 
-packages = [{ include = "pyperch" }]
-
-[tool.poetry.urls]
+[project.urls]
 Homepage = "https://github.com/jlm429/pyperch"
 Repository = "https://github.com/jlm429/pyperch"
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.14"
-torch = ">=2.1,<3.0"
-numpy = ">=1.24"
-optuna = { version = "^4.0", optional = true }
+[project.optional-dependencies]
+optuna = ["optuna>=4.0,<5.0"]
+
+[tool.poetry]
+packages = [{ include = "pyperch" }]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
@@ -31,7 +34,7 @@ scikit-learn = "^1.4"
 matplotlib = "^3.8"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
@@ -50,6 +53,3 @@ indent-style = "space"
 testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "-q"
-
-[tool.poetry.extras]
-optuna = ["optuna"]


### PR DESCRIPTION
## Intent

Perform a focused final PyPerch API and maintenance review limited to two supplied findings. Investigate the asymmetric root optimizer exports with observed imports, documentation, examples, tests, and history, without inventing other findings. The captain explicitly decided to preserve the existing public API boundary: SA and GA remain under pyperch.optim and must not be added at package root. Independently migrate Poetry's deprecated metadata to modern PEP 621 only when behavior-preserving for the maintained Poetry and Python toolchain. Preserve package name, version, description, authorship, readme, MIT license, Python requirement, runtime dependencies, Optuna optional-extra semantics, URLs, entry points, wheel and sdist contents, and build/install behavior. Keep the change metadata-only, update the lock only when Poetry requires it, and do not modify optimizer or search algorithm behavior. Validate with the repository contributor commands, poetry check, package builds, metadata comparison, and optional-extra install behavior.

## What Changed

- Migrated package metadata, runtime dependencies, project URLs, and the Optuna extra from deprecated Poetry fields to PEP 621 `[project]` tables.
- Raised the `poetry-core` build requirement to 2.0 and refreshed the lock content hash while preserving package artifacts and install behavior.

## Risk Assessment

✅ Low: The metadata-only migration preserves package metadata, dependency and optional-extra semantics, artifact configuration, and the intentional optimizer export boundary; the lockfile changes only its required content hash.

## Testing

Poetry and lock validation passed; after correcting the initially empty development environment, the full automated suite passed, both revisions built successfully, package comparison showed preserved metadata and contents, and clean consumer installs demonstrated default and Optuna-extra behavior plus the unchanged optimizer import boundary. No visual evidence was appropriate because the change affects package metadata and Python imports rather than a rendered UI.

<details>
<summary>Evidence: Installed-wheel API and optional-extra verification</summary>

<code>installed distribution: pyperch 0.3.1&#10;optional dependency installed: optuna 4.9.0&#10;root exports preserved: RHC=RHC, RandomizedOptimizer=RandomizedOptimizer&#10;optimizer namespace exports: SA=SA, GA=GA&#10;SA absent from package root: True&#10;GA absent from package root: True</code>

```text
installed distribution: pyperch 0.3.1
optional dependency installed: optuna 4.9.0
root exports preserved: RHC=RHC, RandomizedOptimizer=RandomizedOptimizer
optimizer namespace exports: SA=SA, GA=GA
SA absent from package root: True
GA absent from package root: True
```
</details>
<details>
<summary>Evidence: Base-to-target package comparison</summary>

`Preserved package identity, authorship, Python requirement, URLs, runtime dependencies, Optuna extra, packaged source, entry points, wheel contents, and sdist contents. MIT is equivalently represented using License-Expression.`

```text
preserved Name: pyperch
preserved Version: 0.3.1
preserved Summary: PyTorch-native randomized optimization algorithms.
preserved Author: John Mansfield
preserved Requires-Python: >=3.10,<3.14
preserved Project-URL: ['Homepage, https://github.com/jlm429/pyperch', 'Repository, https://github.com/jlm429/pyperch']
preserved Requires-Dist: ['numpy (>=1.24)', 'optuna (>=4.0,<5.0) ; extra == "optuna"', 'torch (>=2.1,<3.0)']
preserved Provides-Extra: ['optuna']
preserved license semantics: MIT (modernized to License-Expression)
identical packaged pyperch source files: 13
preserved console entry points: none
identical normalized wheel contents: yes
identical sdist contents: yes
```
</details>
<details>
<summary>Evidence: Default installation verification</summary>

<code>default install excludes optional dependency: optuna is not installed&#10;default wheel imports successfully: pyperch 0.3.1</code>

```text
default install excludes optional dependency: optuna is not installed
default wheel imports successfully: pyperch 0.3.1
```
</details>
- Evidence: Target wheel (local file: <code>/var/folders/54/hb_211gx6_5gwww9jh2xz3gc0000gn/T/no-mistakes-evidence/01M0M9KKA9BGXV494GJXETREGE/packages/target/pyperch-0.3.1-py3-none-any.whl</code>)
- Evidence: Target source distribution (local file: <code>/var/folders/54/hb_211gx6_5gwww9jh2xz3gc0000gn/T/no-mistakes-evidence/01M0M9KKA9BGXV494GJXETREGE/packages/target/pyperch-0.3.1.tar.gz</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `poetry check`
- `poetry check --lock`
- <code>`poetry run pytest` (initial attempt identified an empty Poetry environment)</code>
- `poetry install --extras optuna`
- <code>`poetry run pytest` (successful retry after declared dependency installation)</code>
- `poetry build --project <base-evidence-dir>`
- `poetry build --project <target-evidence-dir>`
- `Compared base and target wheel metadata, packaged-source hashes, entry points, normalized wheel contents, and sdist contents`
- <code>Fresh virtual environment: `pip install pyperch-0.3.1-py3-none-any.whl` and verified Optuna remained absent</code>
- <code>Fresh virtual environment: `pip install &#39;pyperch-0.3.1-py3-none-any.whl[optuna]&#39;` and verified installed imports and API boundary</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
