### PR TITLE
fix(optim): correct randomized optimizer RNG and lifecycle state

### DIFF
--- a/docs/general_usage_guide.md
+++ b/docs/general_usage_guide.md
@@ -92,7 +92,9 @@ Parameters:
 - `restart_interval`: number of proposed steps between restarts, regardless of whether
   the proposal at the interval boundary is accepted or rejected. Use `None` to
   disable.
-- `random_state`: optional seed for reproducible random proposals.
+- `random_state`: seed for RHC's private random stream. An integer makes proposal
+  sampling reproducible without reading or changing PyTorch's global random state.
+  `None` creates a freshly seeded private stream.
 
 RHC accepts candidate moves only when they do not increase the loss.
 After a restart, the next call evaluates the randomized parameters without counting
@@ -121,7 +123,9 @@ Parameters:
 - `temperature`: initial annealing temperature.
 - `min_temperature`: lower bound for the temperature.
 - `cooling`: multiplicative cooling rate applied after each step.
-- `random_state`: optional seed for reproducible random proposals.
+- `random_state`: seed for SA's private random stream. An integer makes proposal and
+  acceptance sampling reproducible without reading or changing PyTorch's global
+  random state. `None` creates a freshly seeded private stream.
 
 SA may temporarily accept worse solutions while the temperature is high.
 
@@ -163,7 +167,12 @@ PyPerch optimizers expose a small set of counters and state values to help inspe
 - `accepted_steps`: number of proposed updates accepted.
 - `rejected_steps`: number of proposed updates rejected.
 - `best_loss`: best loss observed by the optimizer.
-- `restore_best()`: restores the best parameter values observed so far.
+- `restore_best()`: restores the best parameter values observed so far and allows
+  optimization to continue from that restored state.
+- `reset_counters()`: clears counters and starts fresh run bookkeeping from the
+  current model parameters without changing those parameters or rewinding the private
+  random stream. RHC restart progress and SA temperature also return to their initial
+  run values.
 
 RHC also exposes:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ bundled data, with no dataset downloads.
 
 | Notebook | Description |
 | --- | --- |
-| [1. Native training](notebooks/01_native_training.ipynb) | RHC closures, frozen layers, and separate Adam/RHC updates. |
+| [1. Native training](notebooks/01_native_training.ipynb) | RHC closures, CUDA/MPS/CPU selection, frozen layers, and separate Adam/RHC updates. |
 | [2. Optimizer comparison](notebooks/02_optimizer_comparison.ipynb) | RHC, SA, GA, and Adam convergence, measured objective calls, and variation across seeds. |
 | [3. Learning and validation curves](notebooks/03_learning_and_validation.ipynb) | Training sample counts, model capacity, and generalization. |
 | [4. Optuna tuning](notebooks/04_optuna_tuning.ipynb) | Repeated trial objectives, search history, and a final test evaluation. |
@@ -26,9 +26,10 @@ set on a laptop CPU, plus installation and first-startup time. No GPU is needed.
 ## Reproducibility
 
 Each notebook specifies seeds, splits, preprocessing, architecture, metrics, and
-training budgets, and prints dependency versions. Runs use float32 on CPU with
-one Torch thread and deterministic operations. Results and timings can vary with
-hardware and dependency versions.
+training budgets, and prints dependency versions. Runs use float32 and deterministic
+operations. The first native-training workflow prefers CUDA, then MPS, and falls back
+to CPU; the remaining workflows use CPU with one Torch thread. Results and timings
+can vary with hardware and dependency versions.
 
 Three-seed curves show means with sample-standard-deviation bands unless labeled
 as an observed range. These describe variation across runs, not confidence

--- a/examples/notebooks/01_native_training.ipynb
+++ b/examples/notebooks/01_native_training.ipynb
@@ -15,8 +15,9 @@
     "\n",
     "The single seeded runs demonstrate optimizer composition, not that one optimizer is\n",
     "generally better than another. Follow the [environment setup](../README.md) before\n",
-    "running. Data, splits, model initialization, and optimizer seeds are fixed. Runs use\n",
-    "CPU, one Torch thread, deterministic operations, and training-only scaling."
+    "running. Data, splits, model initialization, and optimizer seeds are fixed. The\n",
+    "first workflow selects an available accelerator, and later workflows use CPU. All\n",
+    "use one Torch thread, deterministic operations, and training-only scaling."
    ]
   },
   {
@@ -31,7 +32,7 @@
      "text": [
       "Python 3.12.13 | Darwin arm64\n",
       "{'torch': '2.12.0', 'numpy': '2.2.6', 'matplotlib': '3.10.9', 'scikit-learn': '1.7.2', 'optuna': '4.8.0'}\n",
-      "Optimizer SHA256: {'__init__.py': '689555afdfc1', 'base.py': 'cbb9801db916', 'ga.py': '0356d61cd575', 'rhc.py': '5de8c194b8cd', 'sa.py': '100c5c2bab21'}\n"
+      "Optimizer SHA256: {'__init__.py': '689555afdfc1', 'base.py': '84e4727b3d88', 'ga.py': '06561cc5a480', 'rhc.py': 'db6be5d851e4', 'sa.py': '0b23c544c8b5'}\n"
      ]
     }
    ],
@@ -80,7 +81,8 @@
     "A linear model fits a noisy regression target with 25% of observations held out.\n",
     "The closure returns the current training loss, and `step` evaluates one state or\n",
     "candidate move. RHC's first call initializes its objective cache, so 200 calls\n",
-    "contain 199 candidate moves."
+    "contain 199 candidate moves. This example prefers CUDA, then MPS, and falls back\n",
+    "to CPU. Both the model and its data move to the selected device."
    ]
   },
   {
@@ -89,6 +91,13 @@
    "id": "f106cafe",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RHC device: mps\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -103,17 +112,25 @@
     "\n",
     "from pyperch.optim import RHC\n",
     "\n",
+    "if torch.cuda.is_available():\n",
+    "    device = torch.device(\"cuda\")\n",
+    "elif hasattr(torch.backends, \"mps\") and torch.backends.mps.is_available():\n",
+    "    device = torch.device(\"mps\")\n",
+    "else:\n",
+    "    device = torch.device(\"cpu\")\n",
+    "print(\"RHC device:\", device)\n",
+    "\n",
     "rng = np.random.default_rng(42)\n",
     "X = rng.normal(size=(320, 4)).astype(\"float32\")\n",
     "y = 1.5 * X[:, 0] - X[:, 1] + 0.5 * X[:, 2] + rng.normal(0, 0.2, 320)\n",
     "y = y.astype(\"float32\")[:, None]\n",
     "X_train, X_valid, y_train, y_valid = [\n",
-    "    torch.tensor(array)\n",
+    "    torch.tensor(array, device=device)\n",
     "    for array in train_test_split(X, y, test_size=0.25, random_state=42)\n",
     "]\n",
     "\n",
     "torch.manual_seed(42)\n",
-    "model = nn.Linear(4, 1)\n",
+    "model = nn.Linear(4, 1).to(device)\n",
     "loss_fn = nn.MSELoss()\n",
     "optimizer = RHC(model.parameters(), step_size=0.08, random_state=42)\n",
     "\n",
@@ -510,7 +527,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Notebook computation and plotting: 0.84 seconds\n"
+      "Notebook computation and plotting: 1.28 seconds\n"
      ]
     }
    ],

--- a/pyperch/optim/base.py
+++ b/pyperch/optim/base.py
@@ -49,3 +49,29 @@ class RandomizedOptimizer(torch.optim.Optimizer):
         """Update the best loss when improved."""
         if self.best_loss is None or loss < self.best_loss:
             self.best_loss = loss
+
+    @staticmethod
+    def _make_generator(random_state: int | None) -> torch.Generator:
+        """Create a private CPU generator with optional reproducible seeding."""
+        generator = torch.Generator()
+        if random_state is None:
+            generator.seed()
+        else:
+            generator.manual_seed(random_state)
+        return generator
+
+    def _rand_like(self, reference: torch.Tensor) -> torch.Tensor:
+        """Sample uniformly with the private CPU generator and preserve metadata."""
+        return torch.rand(
+            reference.shape,
+            generator=self._generator,
+            dtype=reference.dtype,
+        ).to(reference.device)
+
+    def _randn_like(self, reference: torch.Tensor) -> torch.Tensor:
+        """Sample normally with the private CPU generator and preserve metadata."""
+        return torch.randn(
+            reference.shape,
+            generator=self._generator,
+            dtype=reference.dtype,
+        ).to(reference.device)

--- a/pyperch/optim/ga.py
+++ b/pyperch/optim/ga.py
@@ -56,11 +56,7 @@ class GA(RandomizedOptimizer):
         self.mutation_rate = mutation_rate
         self.step_size = step_size
 
-        self._generator = torch.Generator()
-        if random_state is None:
-            self._generator.seed()
-        else:
-            self._generator.manual_seed(random_state)
+        self._generator = self._make_generator(random_state)
 
     def reset_counters(self) -> None:
         """Reset counters and run-specific state without changing parameters."""
@@ -251,20 +247,6 @@ class GA(RandomizedOptimizer):
 
         return mutated
 
-    def _rand_like(self, reference: torch.Tensor) -> torch.Tensor:
-        return torch.rand(
-            reference.shape,
-            generator=self._generator,
-            dtype=reference.dtype,
-        ).to(reference.device)
-
-    def _randn_like(self, reference: torch.Tensor) -> torch.Tensor:
-        return torch.randn(
-            reference.shape,
-            generator=self._generator,
-            dtype=reference.dtype,
-        ).to(reference.device)
-
     @staticmethod
     def _clone_individual(
         individual: list[torch.Tensor],
@@ -276,3 +258,5 @@ class GA(RandomizedOptimizer):
         """Restore the best parameters observed so far."""
         if self._best_params is not None:
             self._restore_params(self._best_params)
+            self._current_loss = self.best_loss
+            self._initialized = True

--- a/pyperch/optim/rhc.py
+++ b/pyperch/optim/rhc.py
@@ -47,12 +47,12 @@ class RHC(RandomizedOptimizer):
         self.step_size = step_size
         self.restarts = restarts
         self.restart_interval = restart_interval
+        self._generator = self._make_generator(random_state)
+
+    def reset_counters(self) -> None:
+        """Reset counters and run-specific state without changing parameters."""
+        super().reset_counters()
         self.completed_restarts = 0
-
-        self._generator = torch.Generator()
-        if random_state is not None:
-            self._generator.manual_seed(random_state)
-
         self._initialized = False
         self._current_loss: float | None = None
         self._best_params: list[torch.Tensor] | None = None
@@ -112,12 +112,7 @@ class RHC(RandomizedOptimizer):
             for p in group["params"]:
                 if not p.requires_grad:
                     continue
-                noise = torch.randn(
-                    p.shape,
-                    generator=self._generator,
-                    device=p.device,
-                    dtype=p.dtype,
-                )
+                noise = self._randn_like(p)
                 p.add_(step_size * noise)
 
     @torch.no_grad()
@@ -131,12 +126,7 @@ class RHC(RandomizedOptimizer):
             return
 
         for p in self._parameters():
-            noise = torch.randn(
-                p.shape,
-                generator=self._generator,
-                device=p.device,
-                dtype=p.dtype,
-            )
+            noise = self._randn_like(p)
             p.copy_(noise)
 
         self.completed_restarts += 1
@@ -154,3 +144,5 @@ class RHC(RandomizedOptimizer):
         """Restore the best parameter values observed so far."""
         if self._best_params is not None:
             self._restore_params(self._best_params)
+            self._current_loss = self.best_loss
+            self._initialized = True

--- a/pyperch/optim/sa.py
+++ b/pyperch/optim/sa.py
@@ -61,17 +61,18 @@ class SA(RandomizedOptimizer):
             "step_size": step_size,
         }
 
+        self._initial_temperature = temperature
         super().__init__(params, defaults)
 
         self.step_size = step_size
-        self.temperature = temperature
         self.min_temperature = min_temperature
         self.cooling = cooling
+        self._generator = self._make_generator(random_state)
 
-        self._generator = torch.Generator()
-        if random_state is not None:
-            self._generator.manual_seed(random_state)
-
+    def reset_counters(self) -> None:
+        """Reset counters and run-specific state without changing parameters."""
+        super().reset_counters()
+        self.temperature = self._initial_temperature
         self._initialized = False
         self._current_loss: float | None = None
         self._best_params: list[torch.Tensor] | None = None
@@ -119,15 +120,7 @@ class SA(RandomizedOptimizer):
         old_param = param.detach().clone()
 
         with torch.no_grad():
-            noise = (
-                torch.rand(
-                    param.shape,
-                    generator=self._generator,
-                    device=param.device,
-                    dtype=param.dtype,
-                )
-                - 0.5
-            )
+            noise = self._rand_like(param) - 0.5
 
             param.add_(self.step_size * noise)
 
@@ -189,3 +182,5 @@ class SA(RandomizedOptimizer):
         """Restore the best parameters observed so far."""
         if self._best_params is not None:
             self._restore_params(self._best_params)
+            self._current_loss = self.best_loss
+            self._initialized = True

--- a/tests/optim/test_rhc.py
+++ b/tests/optim/test_rhc.py
@@ -144,6 +144,68 @@ def test_rhc_reset_counters():
     assert optimizer.best_loss is None
 
 
+def test_rhc_reset_counters_starts_fresh_run_and_restart_schedule():
+    parameter = nn.Parameter(torch.tensor([0.0]))
+    optimizer = RHC(
+        [parameter],
+        step_size=1.0,
+        restarts=1,
+        restart_interval=1,
+        random_state=7,
+    )
+
+    def closure():
+        return parameter.square().sum()
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+    optimizer.step(closure)
+    assert optimizer.completed_restarts == 1
+
+    with torch.no_grad():
+        parameter.fill_(5)
+    optimizer.reset_counters()
+    fresh_loss = optimizer.step(closure)
+
+    assert fresh_loss.item() == 25
+    assert optimizer.best_loss == 25
+    assert optimizer.function_evals == 1
+    assert optimizer.proposed_steps == 0
+    assert optimizer.accepted_steps == 0
+    assert optimizer.rejected_steps == 0
+    assert optimizer.completed_restarts == 0
+
+    with torch.no_grad():
+        parameter.fill_(7)
+    optimizer.restore_best()
+
+    assert parameter.item() == 5
+
+
+def test_rhc_restore_best_synchronizes_continued_optimization():
+    parameter = nn.Parameter(torch.tensor([0.0]))
+    optimizer = RHC(
+        [parameter],
+        step_size=1.0,
+        restarts=1,
+        restart_interval=1,
+        random_state=1,
+    )
+
+    def closure():
+        return parameter.square().sum()
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+    optimizer.step(closure)
+    optimizer.restore_best()
+    optimizer.step(closure)
+
+    assert parameter.item() == 0
+    assert optimizer.accepted_steps == 0
+    assert optimizer.rejected_steps == 2
+
+
 def test_rhc_accepted_boundary_proposal_restarts():
     optimizer, closure = make_scalar_optimizer(seed=10, restarts=1, restart_interval=1)
 

--- a/tests/optim/test_rng_device.py
+++ b/tests/optim/test_rng_device.py
@@ -1,0 +1,128 @@
+import pytest
+import torch
+from torch import nn
+
+from pyperch.optim import RHC, SA
+
+DEVICE_CASES = [
+    pytest.param(torch.device("cpu"), torch.float32, id="cpu-float32"),
+    pytest.param(torch.device("cpu"), torch.float64, id="cpu-float64"),
+    pytest.param(
+        torch.device("cuda"),
+        torch.float32,
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA is not available"
+        ),
+        id="cuda-float32",
+    ),
+    pytest.param(
+        torch.device("mps"),
+        torch.float32,
+        marks=pytest.mark.skipif(
+            not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),
+            reason="MPS is not available",
+        ),
+        id="mps-float32",
+    ),
+]
+
+
+def run_trajectory(optimizer_type, random_state, unrelated_global_draws=0):
+    torch.manual_seed(1234)
+    torch.rand(unrelated_global_draws)
+
+    parameter = nn.Parameter(torch.zeros(4))
+    optimizer = optimizer_type([parameter], step_size=0.25, random_state=random_state)
+
+    def closure():
+        return parameter.sum()
+
+    losses = [optimizer.step(closure).detach().clone() for _ in range(3)]
+    return torch.stack(losses), parameter.detach().clone()
+
+
+@pytest.mark.parametrize("optimizer_type", [RHC, SA])
+@pytest.mark.parametrize("device,dtype", DEVICE_CASES)
+@pytest.mark.parametrize("candidate_is_accepted", [True, False])
+def test_rhc_and_sa_preserve_device_and_dtype_through_randomized_paths(
+    optimizer_type, device, dtype, candidate_is_accepted
+):
+    parameter = nn.Parameter(torch.zeros(2, device=device, dtype=dtype))
+    kwargs = {"step_size": 0.1, "random_state": 42}
+    if optimizer_type is RHC:
+        kwargs.update(restarts=1, restart_interval=1)
+    optimizer = optimizer_type([parameter], **kwargs)
+    evaluations = 0
+
+    def closure():
+        nonlocal evaluations
+        evaluations += 1
+        loss = parameter.square().sum()
+        if candidate_is_accepted:
+            return loss + int(evaluations == 1)
+        return loss + int(evaluations > 1)
+
+    initial_loss = optimizer.step(closure)
+    later_loss = optimizer.step(closure)
+
+    assert initial_loss.dtype == dtype
+    assert initial_loss.device == parameter.device
+    assert later_loss.dtype == dtype
+    assert later_loss.device == parameter.device
+    assert optimizer.accepted_steps == int(candidate_is_accepted)
+    assert optimizer.rejected_steps == int(not candidate_is_accepted)
+    if optimizer_type is RHC:
+        assert optimizer.completed_restarts == 1
+
+    optimizer.restore_best()
+    assert parameter.dtype == dtype
+    assert parameter.device.type == device.type
+    assert parameter.square().sum().item() == pytest.approx(optimizer.best_loss)
+
+    continued_loss = optimizer.step(closure)
+    assert continued_loss.dtype == dtype
+    assert continued_loss.device == parameter.device
+
+
+@pytest.mark.parametrize("optimizer_type", [RHC, SA])
+def test_rhc_and_sa_same_seed_are_reproducible_and_global_rng_independent(
+    optimizer_type,
+):
+    losses_a, parameters_a = run_trajectory(
+        optimizer_type, 42, unrelated_global_draws=1
+    )
+    losses_b, parameters_b = run_trajectory(
+        optimizer_type, 42, unrelated_global_draws=100
+    )
+
+    assert torch.equal(losses_a, losses_b)
+    assert torch.equal(parameters_a, parameters_b)
+
+
+@pytest.mark.parametrize("optimizer_type", [RHC, SA])
+def test_rhc_and_sa_different_seeds_diverge(optimizer_type):
+    losses_a, parameters_a = run_trajectory(optimizer_type, 1)
+    losses_b, parameters_b = run_trajectory(optimizer_type, 2)
+
+    assert not torch.equal(losses_a, losses_b)
+    assert not torch.equal(parameters_a, parameters_b)
+
+
+@pytest.mark.parametrize("optimizer_type", [RHC, SA])
+@pytest.mark.parametrize("random_state", [42, None])
+def test_rhc_and_sa_do_not_perturb_global_rng(optimizer_type, random_state):
+    torch.manual_seed(1234)
+    state_before = torch.random.get_rng_state()
+
+    run_trajectory(optimizer_type, random_state)
+
+    assert torch.equal(torch.random.get_rng_state(), state_before)
+
+
+@pytest.mark.parametrize("optimizer_type", [RHC, SA])
+def test_rhc_and_sa_none_use_fresh_private_random_streams(optimizer_type):
+    losses_a, parameters_a = run_trajectory(optimizer_type, None)
+    losses_b, parameters_b = run_trajectory(optimizer_type, None)
+
+    assert not torch.equal(losses_a, losses_b)
+    assert not torch.equal(parameters_a, parameters_b)

--- a/tests/optim/test_rng_device.py
+++ b/tests/optim/test_rng_device.py
@@ -121,8 +121,49 @@ def test_rhc_and_sa_do_not_perturb_global_rng(optimizer_type, random_state):
 
 @pytest.mark.parametrize("optimizer_type", [RHC, SA])
 def test_rhc_and_sa_none_use_fresh_private_random_streams(optimizer_type):
-    losses_a, parameters_a = run_trajectory(optimizer_type, None)
-    losses_b, parameters_b = run_trajectory(optimizer_type, None)
+    def run_accepted_proposal():
+        parameter = nn.Parameter(torch.zeros(4))
+        optimizer = optimizer_type([parameter], step_size=0.25, random_state=None)
 
-    assert not torch.equal(losses_a, losses_b)
+        def closure():
+            return torch.zeros(())
+
+        optimizer.step(closure)
+        optimizer.step(closure)
+        assert optimizer.accepted_steps == 1
+        return parameter.detach().clone()
+
+    parameters_a = run_accepted_proposal()
+    parameters_b = run_accepted_proposal()
+
     assert not torch.equal(parameters_a, parameters_b)
+
+
+@pytest.mark.parametrize("optimizer_type", [RHC, SA])
+def test_rhc_and_sa_reset_counters_do_not_rewind_private_rng(optimizer_type):
+    reset_parameter = nn.Parameter(torch.zeros(4))
+    reference_parameter = nn.Parameter(torch.zeros(4))
+    reset_optimizer = optimizer_type([reset_parameter], step_size=0.25, random_state=42)
+    reference_optimizer = optimizer_type(
+        [reference_parameter], step_size=0.25, random_state=42
+    )
+
+    def reset_closure():
+        return torch.zeros(())
+
+    def reference_closure():
+        return torch.zeros(())
+
+    for optimizer, closure in (
+        (reset_optimizer, reset_closure),
+        (reference_optimizer, reference_closure),
+    ):
+        optimizer.step(closure)
+        optimizer.step(closure)
+
+    reset_optimizer.reset_counters()
+    reset_optimizer.step(reset_closure)
+    reset_optimizer.step(reset_closure)
+    reference_optimizer.step(reference_closure)
+
+    assert torch.equal(reset_parameter, reference_parameter)

--- a/tests/optim/test_sa.py
+++ b/tests/optim/test_sa.py
@@ -119,3 +119,66 @@ def test_sa_reset_counters():
     assert optimizer.accepted_steps == 0
     assert optimizer.rejected_steps == 0
     assert optimizer.best_loss is None
+
+
+def test_sa_reset_counters_starts_fresh_run_and_temperature_schedule():
+    parameter = nn.Parameter(torch.tensor([0.0]))
+    optimizer = SA(
+        [parameter],
+        step_size=0.1,
+        temperature=2.0,
+        min_temperature=0.1,
+        cooling=0.5,
+        random_state=7,
+    )
+
+    def closure():
+        return parameter.square().sum()
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+    assert optimizer.temperature == 1.0
+
+    with torch.no_grad():
+        parameter.fill_(5)
+    optimizer.reset_counters()
+    fresh_loss = optimizer.step(closure)
+
+    assert fresh_loss.item() == 25
+    assert optimizer.best_loss == 25
+    assert optimizer.function_evals == 1
+    assert optimizer.proposed_steps == 0
+    assert optimizer.accepted_steps == 0
+    assert optimizer.rejected_steps == 0
+    assert optimizer.temperature == 2.0
+
+    with torch.no_grad():
+        parameter.fill_(7)
+    optimizer.restore_best()
+
+    assert parameter.item() == 5
+
+
+def test_sa_restore_best_synchronizes_continued_optimization():
+    parameter = nn.Parameter(torch.tensor([0.0]))
+    optimizer = SA(
+        [parameter],
+        step_size=2.0,
+        temperature=1000.0,
+        min_temperature=1e-12,
+        cooling=1.0,
+        random_state=0,
+    )
+
+    def closure():
+        return parameter.square().sum()
+
+    optimizer.step(closure)
+    optimizer.step(closure)
+    optimizer.temperature = 1e-12
+    optimizer.restore_best()
+    optimizer.step(closure)
+
+    assert parameter.item() == 0
+    assert optimizer.accepted_steps == 1
+    assert optimizer.rejected_steps == 1


### PR DESCRIPTION
## Intent

Implement the first focused optimizer follow-up from the recent randomized optimizer audit, treating the audit as evidence and inspecting current optimizer code, tests, documented usage, maintained notebooks, and recent optimizer history while preserving behavior corrected by recent work. Revisit GitHub issue #23 and fix the confirmed accelerator RNG problem in randomized hill climbing and simulated annealing. Review RNG handling across RHC, SA, and GA for consistent, compatible semantics, including random_state=None, and make only the smallest required changes. Correct fresh-run reset behavior so stale cached loss, best state, or algorithm lifecycle state cannot survive; reset RHC restart progress and SA temperature consistently without changing current model parameters or rewinding the private RNG. Correct restore_best() so internal optimizer state matches restored model parameters and subsequent public optimization behavior. Add focused behavioral regression tests at observable causal boundaries based on faithful reproduction, distinguishing triggers, masking conditions, visible symptoms, failing and proven paths, and causal counterfactuals. Resolve ambiguity with the smallest behavior consistent with the existing API and usage. Keep the patch focused with no parameter-group semantics, checkpoint serialization, API redesign, dependencies, unrelated refactors, formatting churn, or cleanup unless minimally required. Preserve compatibility with ordinary native PyTorch model.parameters() usage, docs, and maintained notebooks. Validate focused optimizer tests, the full project suite, and available device and dtype paths, reporting CPU, CUDA, MPS, device, and dtype paths actually exercised, skipped, or unavailable without implying unavailable coverage passed. Execute every maintained example notebook from a clean state and treat failures as regressions unless clearly unrelated; do not rewrite outputs or examples merely to pass validation. Update issue #23 when warranted and keep it open unless all scope is genuinely resolved, reporting remaining gaps. Add a small GPU/device example to the most appropriate existing maintained notebook that prefers CUDA when available, otherwise MPS, and falls back cleanly to CPU, moves the model and data to that device, and runs a PyPerch optimizer; integrate it into the existing example rather than creating a notebook, and execute the edited notebook from a clean state. Commit the focused implementation and regression tests, then validate and ship through the configured pipeline.

## What Changed

- Fix RHC and SA random sampling on CUDA and MPS while preserving tensor dtype, private RNG isolation, reproducible seeds, and fresh streams for `random_state=None`; share the same sampling helpers with GA.
- Reset cached loss, best parameters, restart progress, and annealing temperature for fresh runs, and synchronize cached loss when `restore_best()` restores model parameters.
- Add device, dtype, RNG, reset, and continued-optimization regression coverage, plus updated guidance and an accelerator-aware native training notebook example.

## Risk Assessment

✅ Low: The focused changes consistently fix private RNG device compatibility and synchronize reset and restore lifecycle state across RHC, SA, and GA without introducing a source-verifiable regression or intent contradiction.

## Testing

Focused RHC, SA, and GA RNG, reset, restore-best, accepted/rejected, device, and dtype behavior passed on CPU float32, CPU float64, and MPS float32; CUDA was unavailable and its four cases skipped. The changed notebook executed cleanly from a fresh kernel on MPS and was exported as rendered evidence. Broad suite and unchanged notebooks were left to their outer validation phases.

<details>
<summary>Evidence: Rendered native training notebook</summary>

<code>Fresh execution selected `RHC device: mps` and reported restored validation MSE 0.0486 versus 3.3505 for the constant reference, with 200 objective calls.</code>

```text
<!DOCTYPE html>

<html lang="en">
<head><meta charset="utf-8"/>
<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
<title>native_training_executed</title><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script><script type="module">
  import mermaid from 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.10.0/mermaid.esm.min.mjs';
  
  mermaid.initialize({ startOnLoad: true });
</script>
<style type="text/css">
  pre { line-height: 125%; }
td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
.highlight .hll { background-color: #ffffcc }
.highlight { background: #f8f8f8; }
.highlight .c { color: #3D7B7B; font-style: italic } /* Comment */
.highlight .err { border: 1px solid #F00 } /* Error */
.highlight .k { color: #008000; font-weight: bold } /* Keyword */
.highlight .o { color: #666 } /* Operator */
.highlight .ch { color: #3D7B7B; font-style: italic } /* Comment.Hashbang */
.highlight .cm { color: #3D7B7B; font-style: italic } /* Comment.Multiline */
.highlight .cp { color: #9C6500 } /* Comment.Preproc */
.highlight .cpf { color: #3D7B7B; font-style: italic } /* Comment.PreprocFile */
.highlight .c1 { color: #3D7B7B; font-style: italic } /* Comment.Single */
.highlight .cs { color: #3D7B7B; font-style: italic } /* Comment.Special */
.highlight .gd { color: #A00000 } /* Generic.Deleted */
.highlight .ge { font-style: italic } /* Generic.Emph */
.highlight .ges { font-weight: bold; font-style: italic } /* Generic.EmphStrong */
.highlight .gr { color: #E40000 } /* Generic.Error */
.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
.highlight .gi { color: #008400 } /* Generic.Inserted */
.highlight .go { color: #717171 } /* Generic.Output */
.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
.highlight .gs { font-weight: bold } /* Generic.Strong */
.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
.highlight .gt { color: #04D } /* Generic.Traceback */
.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
.highlight .kp { color: #008000 } /* Keyword.Pseudo */
.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
.highlight .kt { color: #B00040 } /* Keyword.Type */
.highlight .m { color: #666 } /* Literal.Number */
.highlight .s { color: #BA2121 } /* Literal.String */
.highlight .na { color: #687822 } /* Name.Attribute */
.highlight .nb { color: #008000 } /* Name.Builtin */
.highlight .nc { color: #00F; font-weight: bold } /* Name.Class */
.highlight .no { color: #800 } /* Name.Constant */
.highlight .nd { color: #A2F } /* Name.Decorator */
.highlight .ni { color: #717171; font-weight: bold } /* Name.Entity */
.highlight .ne { color: #CB3F38; font-weight: bold } /* Name.Exception */
.highlight .nf { color: #00F } /* Name.Function */
.highlight .nl { color: #767600 } /* Name.Label */
.highlight .nn { color: #00F; font-weight: bold } /* Name.Namespace */
.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
.highlight .nv { color: #19177C } /* Name.Variable */
.highlight .ow { color: #A2F; font-weight: bold } /* Operator.Word */
.highlight .w { color: #BBB } /* Text.Whitespace */
.highlight .mb { color: #666 } /* Literal.Number.Bin */
.highlight .mf { color: #666 } /* Literal.Number.Float */
.highlight .mh { color: #666 } /* Literal.Number.Hex */
.highlight .mi { color: #666 } /* Literal.Number.Integer */
.highlight .mo { color: #666 } /* Literal.Number.Oct */
.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
.highlight .sc { color: #BA2121 } /* Literal.String.Char */
.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
.highlight .se { color: #AA5D1F; font-weight: bold } /* Literal.String.Escape */
.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
.highlight .si { color: #A45A77; font-weight: bold } /* Literal.String.Interpol */
.highlight .sx { color: #008000 } /* Literal.String.Other */
.highlight .sr { color: #A45A77 } /* Literal.String.Regex */
.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
.highlight .ss { color: #19177C } /* Literal.String.Symbol */
.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
.highlight .fm { color: #00F } /* Name.Function.Magic */
.highlight .vc { color: #19177C } /* Name.Variable.Class */
.highlight .vg { color: #19177C } /* Name.Variable.Global */
.highlight .vi { color: #19177C } /* Name.Variable.Instance */
.highlight .vm { color: #19177C } /* Name.Variable.Magic */
.highlight .il { color: #666 } /* Literal.Number.Integer.Long */
  </style>
<style type="text/css">
/*!
*
* Twitter Bootstrap
*
*/
/*!
 * Bootstrap v3.3.7 (http://getbootstrap.com)
 * Copyright 2011-2016 Twitter, Inc.
 * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
 */
/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
html {
  font-family: sans-serif;
  -ms-text-size-adjust: 100%;
  -webkit-text-size-adjust: 100%;
}
body {
  margin: 0;
}
article,
aside,
details,
figcaption,
figure,
footer,
header,
hgroup,
main,
menu,
nav,
section,
summary {
  display: block;
}
audio,
canvas,
progress,
video {
  display: inline-block;
  vertical-align: baseline;
}
audio:not([controls]) {
  display: none;
  height: 0;
}
[hidden],
template {
  display: none;
}
a {
  background-color: transparent;
}
a:active,
a:hover {
  outline: 0;
}
abbr[title] {
  border-bottom: 1px dotted;
}
b,
strong {
  font-weight: bold;
}
dfn {
  font-style: italic;
}
h1 {
  font-size: 2em;
  margin: 0.67em 0;
}
mark {
  background: #ff0;
  color: #000;
}
small {
  font-size: 80%;
}
sub,
sup {
  font-size: 75%;
  line-height: 0;
  position: relative;
  vertical-align: baseline;
}
sup {
  top: -0.5em;
}
sub {
  bottom: -0.25em;
}
img {
  border: 0;
}
svg:not(:root) {
  overflow: hidden;
}
figure {
  margin: 1em 40px;
}
hr {
  box-sizing: content-box;
  height: 0;
}
pre {
  overflow: auto;
}
code,
kbd,
pre,
samp {
  font-family: monospace, monospace;
  font-size: 1em;
}
button,
input,
optgroup,
select,
textarea {
  color: inherit;
  font: inherit;
  margin: 0;
}
button {
  overflow: visible;
}
button,
select {
  text-transform: none;
}
button,
html input[type="button"],
input[type="reset"],
input[type="submit"] {
  -webkit-appearance: button;
  cursor: pointer;
}
button[disabled],
html input[disabled] {
  cursor: default;
}
button::-moz-focus-inner,
input::-moz-focus-inner {
  border: 0;
  padding: 0;
}
input {
  line-height: normal;
}
input[type="checkbox"],
input[type="radio"] {
  box-sizing: border-box;
  padding: 0;
}
input[type="number"]::-webkit-inner-spin-button,
input[type="number"]::-webkit-outer-spin-button {
  height: auto;
}
input[type="search"] {
  -webkit-appearance: textfield;
  box-sizing: content-box;
}
input[type="search"]::-webkit-search-cancel-button,
input[type="search"]::-webkit-search-decoration {
  -webkit-appearance: none;
}
fieldset {
  border: 1px solid #c0c0c0;
  margin: 0 2px;
  padding: 0.35em 0.625em 0.75em;
}
legend {
  border: 0;
  padding: 0;
}
textarea {
  overflow: auto;
}
optgroup {
  font-weight: bold;
}
table {
  border-collapse: collapse;
  border-spacing: 0;
}
td,
th {
  padding: 0;
}
/*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
@media print {
  *,
  *:before,
  *:after {
    background: transparent !im

... [477434 bytes truncated] ...

yzhZywiIiIi7srfxwtNQoPMkt2Zc6k4kBm47Mv8eSAzI5OYYg1yuCzbFZ1rtzLbsDIOKePQMl4u6/UxpZ5ZYYDSuXNnTJ8+3VzOyMhARESEyXpMmDAh18zKmDFjTMYkN3w6tWrVwmOPPYZx48aZ6xixhYaGmvveeuut2L59O1q0aIF//vkHnTp1MussXLgQAwYMwJEjR8z9C6LMioiIiIhcDBaLBdEJydhvz8ZkBTMHTyYiNT3v0/kgp/qYzKxMcCDqBVdEkH/ptV0uE5mVlJQUrFu3DhMnTrRfxyFZffv2xcqVK/O8X0JCAurWrWsCmw4dOuCFF15Ay5YtzW379+83w8m4DRseCAZF3CaDFf6sUqWKPVAhrs/HXr16NW644YYcj5mcnGwWxwMsIiIiIlLSPDw8EBLkb5auDao73ZaWnoFjsUmmS5k9E5MZyLA+Jj4pDZuOnDGLo2oBvlj/9JUu/+KVarASExOD9PR0k/VwxMs7duzI9T5NmzbFRx99hDZt2phI7JVXXkH37t2xdetWhIeHm0DFto3s27Tdxp/Zh5h5e3ujWrVq9nWymzp1KqZMmXJez1dERERE5ELy9vJEneoVzXJ508LXx9StHlAmXohSr1kpqm7dupnFhoFK8+bN8e677+K5554rscdl9oe1NY6ZFQ5XExEREREpa/UxyWl5t1Z2JaU6rWZwcDC8vLxw4sQJp+t5uWbNmoXaho+PD9q3b489e/aYy7b75bdN/oyKinK6PS0tzXQIy+tx2XGM4+kcFxERERGRssivjLRBLtVgxdfXFx07dsSiRYvs17EOhZcdsyf54TCyzZs3IywszFxm9y8GHI7bZBaEtSi2bfInC/RZL2OzePFi89isbRERERERkdJX6sPAOLRq2LBhptidc6uwdXFiYqJ9LpWhQ4eidu3apmaEnn32WVxyySVo1KiRCTg4P8vBgwcxfPhwewESu4U9//zzZl4VW+tidvi6/vrrzTocNnb11VdjxIgRpmUyWxePGjXKFN8XphOYiIiIiIi4QbByyy23IDo6GpMmTTLF7e3atTNthG0F8ocOHTJdumxOnz5tggyuW7VqVZOZWbFihWlFbDN+/HgT8HDeFAY0l156qdmmbY4V+uKLL0yA0qdPH/ukkJybRUREREREXEOpz7NSVmmeFRERERGRkj2XLtWaFRERERERkbwoWBEREREREZekYEVERERERFySghUREREREXFJClZERERERMQlKVgRERERERGXpGBFRERERERcUqlPCllW2aanYY9oEREREREpPNs5dEFTPipYKab4+HjzMyIioribEBERERGBu59TV65cOc/bNYN9MWVkZODYsWMICgqCh4cHSisiZbB0+PDhfGf+FB1HvR/LDv1d6zi6Er0fdSxdjd6T5ec4MqPCQKVWrVrw9My7MkWZlWLiQQ0PD4cr4JtMwYqOo6vQ+1HH0ZXo/ajj6Gr0ntRxdCWVSvkcMr+Mio0K7EVERERExCUpWBEREREREZekYKUM8/Pzw+TJk81P0XEsbXo/6ji6Er0fdRxdjd6TOo6uxK8MnUOqwF5ERERERFySMisiIiIiIuKSFKyIiIiIiIhLUrAiIiIiIiIuScGKiIiIiIi4JAUrLm7GjBmoV68e/P390bVrV6xZsybf9b/77js0a9bMrN+6dWssWLAA7mzq1Kno3LkzgoKCEBISguuvvx47d+7M9z6zZ8+Gh4eH08Lj6c6eeeaZHMeE77P86L2YE/+Wsx9HLiNHjsz1GOq9aLV8+XJce+21ZpZjHq+5c+fmmAV50qRJCAsLQ4UKFdC3b1/s3r37gn++lvdjmZqaiscff9z83xEQEGDWGTp0KI4dO3bBPx/K+3vyrrvuynFMrr766gK3627vyYKOY26fl1ymTZuW5zbd7f04tRDnOUlJSeb/merVqyMwMBCDBw/GiRMn8t1ucT9XS4KCFRf2zTffYOzYsaa13Pr169G2bVv069cPUVFRua6/YsUK3Hbbbbj33nvx77//mjcsly1btsBdLVu2zPyBrlq1Cr///rv5z/iqq65CYmJivvfjbK6RkZH25eDBg3B3LVu2dDomf/31V57r6r2Yu3/++cfpGPI9STfddFOex1LvRZi/V37+8UQuNy+//DLeeustzJo1C6tXrzYn2vys5H/QF+rz1R2O5dmzZ82xePrpp83PH374wZz0XHfddRf088Ed3pPE4MTxmHz11Vf5btMd35MFHUfH48flo48+MsEHT7bz407vx2WFOM959NFHMW/ePPMlItfnFxCDBg3Kd7vF+VwtMRZxWV26dLGMHDnSfjk9Pd1Sq1Yty9SpU3Nd/+abb7Zcc801Ttd17drVcv/995f4vpYVUVFRFr7tly1bluc6H3/8saVy5coXdb9c3eTJky1t27Yt9Pp6LxbO6NGjLQ0bNrRkZGTkerveiznx73fOnDn2yzx2NWvWtEybNs1+XWxsrMXPz8/y1VdfXbDPV3c4lrlZs2aNWe/gwYMX7PPBHY7jsGHDLAMHDizSdtz9PVmY9yOP6RVXXJHvOu7+fozKdp7Dz0MfHx/Ld999Z19n+/btZp2VK1fmuo3ifq6WFGVWXFRKSgrWrVtn0m42np6e5vLKlStzvQ+vd1yfGAXntb47OnPmjPlZrVq1fNdLSEhA3bp1ERERgYEDB2Lr1q1wd0z/MlXfoEEDDBkyBIcOHcpzXb0XC/c3/vnnn+Oee+4x3xTmRe/F/O3fvx/Hjx93+uyrXLmyGUKT12dfcT5f3fkzk+/PKlWqXLDPB3exdOlSMyynadOmePDBB3Hy5Mk819V7smActjR//nwzeqQg7vx+PJPtPIefdcy2OH7ecVhcnTp18vy8K87naklSsOKiYmJikJ6ejtDQUKfreZlvoNzw+qKs724yMjIwZswY9OjRA61atcpzPf7HwlTzjz/+aE4meb/u3bvjyJEjcFf8gGL9xMKFCzFz5kzzQdazZ0/Ex8fnur7eiwXj2OzY2Fgztj0vei8WzPb5VpTPvuJ8vrojDvdgDQuHF3M44oX6fHAHHAL26aefYtGiRXjppZfM0Jv+/fub911u9J4s2CeffGLqMgoavuTO78eMXM5z+Jnm6+ub4wuHgs4nbesU9j4lyfuiP6JIKeGYTtbvFDR2tVu3bmaxYaDSvHlzvPvuu3juuefgjvifrE2bNm3MfwbMPH377beF+pZLcvrwww/NceW3f3nRe1FKC7+Jvfnmm02RLU/48qPPh5xuvfVW++9sWMDPzYYNG5psS58+fUrgFSv/+CUisyQFNbxx5/fjyEKe55Q1yqy4qODgYHh5eeXo1sDLNWvWzPU+vL4o67uTUaNG4eeff8aSJUsQHh5epPv6+Pigffv22LNnT4ntX1nDb2iaNGmS5zHRezF/bNjwxx9/YPjw4UU67nov5v5eo6J89hXn89UdAxW+T1mwm19WpTifD+6Iw5H4vsvrmOg9mb8///zTNHso6memO70fR+VxnsPPNA4zZCa/KOeTtnUKe5+SpGDFRTFl17FjR5NCdkzv8bLjt/6OeL3j+sT/aPJa3x3wW0H+Ac+ZMweLFy9G/fr1i7wNpu03b95s2vdJVh3F3r178zwmei/m7+OPPzZj2a+55hq9F88T/6b5n6fjZ19cXJzpXpPXZ19xPl/dLVDhmH8G1Gx1eqE/H9wRhxGzZiWvY6L3ZMGZaP7NsnNYUZX396OlgPMcHjd+0eX4ecfAj3U8eX3eFedztURd9JJ+KbSvv/7adF6YPXu2Zdu2bZb77rvPUqVKFcvx48fN7XfeeadlwoQJ9vX//vtvi7e3t+WVV14xnR7YEYMdIDZv3uy2R/3BBx80nb2WLl1qiYyMtC9nz561r5P9OE6ZMsXy66+/Wvbu3WtZt26d5dZbb7X4+/tbtm7danFXjz32mDmG+/fvN++zvn37WoKDg03XEdJ7sfDY4adOnTqWxx9/PMdtei/mLj4+3vLvv/+ahf9tvfbaa+Z3W4eqF1980Xw2/vjjj5ZNmzaZjkH169e3nDt3zr4NdhB6++23C/356o7HMiUlxXLddddZwsPDLRs2bHD6zExOTs7zWBb0+eBux5G3jRs3znRa4jH5448/LB06dLA0btzYkpSUZN+G3pMF/23TmTNnLBUrVrTMnDkz19fC3d+PDxbiPOeBBx4w/+8sXrzYsnbtWku3bt3M4qhp06aWH374wX65MJ+rF4uCFRfHP0C+wXx9fU1bw1WrVtlvu+yyy0x7REfffvutpUmTJmb9li1bWubPn29xZ/zwy21hS9i8juOYMWPsxzw0NNQyYMAAy/r16y3u7JZbbrGEhYWZY1K7dm1zec+ePfbb9V4sPAbCfA/u3Lkzx216L+ZuyZIluf4d2/5u2Wbz6aefNn+vDED69OmT4/jWrVvXfIFT2M9XdzyWPLnL6zOT98vrWBb0+eBux5EniVdddZWlRo0a5gtDHq8RI0bkCIT1niz4b5veffddS4UKFUzr3Ny4+/sRhTjPYYDx0EMPWapWrWoCvxtuuMEENNm343ifwnyuXiwemTsoIiIiIiLiUlSzIiIiIiIiLknBioiIiIiIuCQFKyIiIiIi4pIUrIiIiIiIiEtSsCIiIiIiIi5JwYqIiIiIiLgkBSsiIiIiIuKSFKyIiIiIiIhLUrAiIiIXzYEDB+Dh4YENGzYU+b7PPPMM2rVrl+86d911F66//nqUlnr16uGNN94otccXESlvFKyIiEiB8goCli5daoKP2NjYEj+K48aNw6JFi0r8cURExHV4l/YOiIiI5MdisSA9PR2BgYFmERER96HMioiIXBCJiYmoVKkSvv/+e6fr586di4CAAMTHx9uv27FjB7p37w5/f3+0atUKy5Yty5Gt+eWXX9CxY0f4+fnhr7/+yjEMjAHM2LFjUaVKFVSvXh3jx483gU1B/v77b1x++eWoWLEiqlatin79+uH06dP49NNPzXaSk5Od1mdG6c4777RfnjdvHjp37mz2PTg4GDfccEOej8WM0/Dhw1GjRg1zbK644gps3LjRfjt/7927N4KCgsztfL5r164t8DmIiLgLBSsiInJBMCC59dZb8fHHHztdz8s33nijOSG3+c9//oPHHnsM//77L7p164Zrr70WJ0+edLrfhAkT8OKLL2L79u1o06ZNjsd79dVXMXv2bHz00UcmmDl16hTmzJmT7z6yVqZPnz5o0aIFVq5cae7Hx2bgc9NNN5mfP/30k339qKgozJ8/H/fcc4+5zN8ZnAwYMMDsO4eldenSJc/H4za5DQZe69atQ4cOHczjc19pyJAhCA8Pxz///GNu53P28fEp8FiLiLgNi4iISAGGDRtm8fLysgQEBDgt/v7+TGVYTp8+bdZbvXq1We/YsWPm8okTJyze3t6WpUuXmsv79+8367/44ov2baemplrCw8MtL730krm8ZMkSs87cuXOd9mHy5MmWtm3b2i+HhYVZXn755RzbGThwYJ7P47bbbrP06NEjz9sffPBBS//+/e2XX331VUuDBg0sGRkZ5nK3bt0sQ4YMyfP+devWtbz++uvm9z///NNSqVIlS1JSktM6DRs2tLz77rvm96CgIMvs2bPz3J6IiLtTZkVERAqFw5WYmXBcPvjgA6d1mGVo2bIlPvnkE3P5888/R926ddGrVy+n9ZhNsfH29kanTp1MBsURr8vLmTNnEBkZia5du+bYTmEyK3kZMWIEfvvtNxw9etRcZuaGzQU4LK0w93fEIV4JCQlmaJmt3obL/v37sXfvXrMOh7FxmFjfvn1NFsl2vYiIWKnAXkRECj3Mq1GjRk7XHTlyJMd6PPmeMWOGGdLEIWB33323/WS/qI93oVWoUCHf29u3b4+2bdua+pWrrroKW7duNUO/Cnt/RwxUwsLCTA1OdqyzIdbh3H777eYxOFRs8uTJ+Prrr/OtgxERcSfKrIiIyAV1xx134ODBg3jrrbewbds2DBs2LMc6q1atsv+elpZm6jWaN29e6MeoXLmyCQRWr16dYzv5Ye1LQe2PGWwxo8JAixmPiIiIIt3fhvUpx48fNxkfBnmOCwvzbZo0aYJHH33UZHQGDRqUo+ZHRMSdKVgREZELih22eNLNInpmJ1hAnh0zLyyGZ1ewkSNHmm5ctiL2who9erQZOsVuY9zOQw89VOB8LxMnTjTF7Fx306ZN5n4zZ85ETEyMfR1mOpgxev/993PsEzMfX331lfnJYWubN2/GSy+9lOtjMdDhcDd2E2MgwgkxV6xYgSeffNJ0/Dp37hxGjRplMi8M7tiljPtWlKBNRKS8U7AiIiIX3L333ouUlJQ8AxAGGVw45IodudiByzHbUBjsJsaWwszcMChgt7GChk8xi8HAgfUkrK/h/X788UeT/XDM2gwePNjUl2SfCJMtj7/77juzv2yjzFbEa9asyfWxOPRtwYIFpl6HQ+H42OyWxsAkNDQUXl5epgPa0KFDzW0333wz+vfvjylTphTpOIiIlGcerLIv7Z0QEZHy5bPPPjNDm44dOwZfX1+UNSyiZ6MADmUTEZHSowJ7ERG5YM6ePWu6dDFrcv/995e5QIXD0Tgsi8s777xT2rsjIuL2NAxMREQumJdffhnNmjVDzZo1TX1IWcNuYGxVzDqUpk2blvbuiIi4PQ0DExERERERl6TMioiIiIiIuCQFKyIiIiIi4pIUrIiIiIiIiEtSsCIiIiIiIi5JwYqIiIiIiLgkBSsiIiIiIuKSFKyIiIiIiIhLUrAiIiIiIiJwRf8P5ezaJSQ+AeIAAAAASUVORK5CYII="/>
</div>
</div>
</div>
</div>
</div>
<div class="cell border-box-sizing text_cell rendered" id="cell-id=7d1866d3"><div class="prompt input_prompt">
</div><div class="inner_cell">
<div class="text_cell_render border-box-sizing rendered_html">
<p>Next: <a href="02_optimizer_comparison.ipynb">optimizer comparison</a>.</p>
</div>
</div>
</div>
<div class="cell border-box-sizing code_cell rendered" id="cell-id=995e1a03">
<div class="input">
<div class="prompt input_prompt">In [8]:</div>
<div class="inner_cell">
<div class="input_area">
<div class="highlight hl-ipython3"><pre><span></span><span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"Notebook computation and plotting: </span><span class="si">{</span><span class="n">perf_counter</span><span class="p">()</span><span class="w"> </span><span class="o">-</span><span class="w"> </span><span class="n">started</span><span class="si">:</span><span class="s2">.2f</span><span class="si">}</span><span class="s2"> seconds"</span><span class="p">)</span>
</pre></div>
</div>
</div>
</div>
<div class="output_wrapper">
<div class="output">
<div class="output_area">
<div class="prompt"></div>
<div class="output_subarea output_stream output_stdout output_text">
<pre>Notebook computation and plotting: 17.78 seconds
</pre>
</div>
</div>
</div>
</div>
</div>
</div>
</div>
</main>
</body>
</html>
```
</details>

- Evidence: Freshly executed native training notebook (local file: <code>~/.no-mistakes/evidence/01M23A46DJVMY5AXBF1H0QB68Y/native_training_executed.ipynb</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0d710f8fc0937e5d8e5cee1624f1d0a479def0c1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial focused `pytest` and `poetry run pytest` attempts identified the missing local PyTorch environment; `poetry install --extras notebooks` repaired setup.</code>
- `poetry run pytest -vv tests/optim/test_rng_device.py tests/optim/test_rhc.py::test_rhc_reset_counters_starts_fresh_run_and_restart_schedule tests/optim/test_rhc.py::test_rhc_restore_best_synchronizes_continued_optimization tests/optim/test_sa.py::test_sa_reset_counters_starts_fresh_run_and_temperature_schedule tests/optim/test_sa.py::test_sa_restore_best_synchronizes_continued_optimization`
- `poetry run pytest -q tests/optim/test_ga.py::test_ga_preserves_loss_dtype_and_device_after_initialization tests/optim/test_ga.py::test_ga_reset_counters_starts_fresh_best_state tests/optim/test_ga.py::test_ga_same_seed_is_reproducible_and_global_rng_independent tests/optim/test_ga.py::test_ga_different_seeds_diverge tests/optim/test_ga.py::test_ga_does_not_perturb_global_rng tests/optim/test_ga.py::test_ga_none_uses_a_fresh_private_random_stream`
- `poetry run jupyter nbconvert --to notebook --execute examples/notebooks/01_native_training.ipynb --output native_training_executed.ipynb --output-dir ~/.no-mistakes/evidence/01M23A46DJVMY5AXBF1H0QB68Y --ExecutePreprocessor.timeout=600`
- `poetry run jupyter nbconvert --to html --template classic ~/.no-mistakes/evidence/01M23A46DJVMY5AXBF1H0QB68Y/native_training_executed.ipynb --output native_training_executed.html --output-dir ~/.no-mistakes/evidence/01M23A46DJVMY5AXBF1H0QB68Y`
- `Parsed the generated notebook output contract and confirmed zero execution errors, MPS selection, restored validation MSE, and optimizer counters.`
- `Removed the repository-local virtual environment, pytest caches, and Python bytecode generated during testing.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
