### PR TITLE
docs: strengthen PyPerch agent workflows

### DIFF
--- a/.agents/skills/add-or-modify-optimizer/SKILL.md
+++ b/.agents/skills/add-or-modify-optimizer/SKILL.md
@@ -38,8 +38,9 @@ Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md) for repository validation com
   stochastic choice so equal seeds reproduce independently of PyTorch global RNG,
   `None` starts a fresh private stream, and counter resets do not rewind it.
 - Count `function_evals` as actual closure calls. Use proposal units for RHC and SA
-  step counters and generation units for GA after initialization. Keep
-  `accepted_steps + rejected_steps == proposed_steps`.
+  step counters and generation units for GA after initialization. Count each
+  documented proposal or generation outcome exactly once as accepted or rejected,
+  while keeping initialization and other algorithm-specific units separate.
 - Keep `best_loss` and its parameter checkpoint consistent. `restore_best()` restores
   the global best and synchronizes current-loss bookkeeping without rewinding
   counters, schedules, retained population, or RNG state.
@@ -59,12 +60,12 @@ Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md) for repository validation com
 - SA accepts non-worsening proposals and accepts a worse proposal with Metropolis
   probability `exp(-loss increase / temperature)`. Cool after each proposal and
   respect the configured temperature floor.
-- GA initializes one population once, then retains it across calls. Preserve a
-  deterministic best-half elite set, with at least one elite and cached fitness.
-  Create and evaluate only new children through uniform crossover and group-scaled
-  mutation, and make each later call one generation. Keep current model parameters
-  aligned with the best current individual and checkpoint the full population and
-  its fitness while preserving the global best separately.
+- GA initializes one population once, then retains it across calls. Preserve
+  documented selection, crossover, mutation, and fitness-caching semantics, and
+  evaluate only individuals whose fitness is not already known. Make each later call
+  one generation. Keep current model parameters aligned with the best current
+  individual and checkpoint the full population and its fitness while preserving the
+  global best separately.
 
 ## Workflow
 

--- a/.agents/skills/add-or-modify-optimizer/SKILL.md
+++ b/.agents/skills/add-or-modify-optimizer/SKILL.md
@@ -1,67 +1,103 @@
 ---
 name: add-or-modify-optimizer
-description: Add or change a PyPerch randomized optimizer while preserving native PyTorch use, local optimizer conventions, and focused evidence. Use for optimizer implementation work, not search-only or documentation-only tasks.
+description: Add or change a PyPerch randomized optimizer while preserving native PyTorch use, algorithm semantics, state continuity, and focused evidence. Use for optimizer implementation work, not search-only, notebook-only, or documentation-only tasks.
 ---
 
 # Add or modify an optimizer
 
-Read the repository [agent guide](../../../AGENTS.md) first. This workflow adds the
-optimizer-specific detail that does not belong in the always-loaded guide.
+## When to use
 
-## Establish the local contract
+Use this skill for behavior, state, or public API changes in `pyperch/optim/`.
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md) for repository validation commands.
 
-1. Read the algorithm carefully enough to identify its state, proposal, acceptance,
-   evaluation, and randomization rules before choosing an API.
-2. Inspect `pyperch/optim/base.py`, neighboring optimizer implementations,
-   `tests/optim/`, the relevant notebooks listed in `examples/README.md`, and
-   `docs/general_usage_guide.md`. Check public exports when adding a class.
-3. For a bug fix, reproduce the user-visible failure through a normal PyTorch usage
-   path before changing code.
-4. Follow local patterns where they express a shared contract, but do not
-   mechanically force different algorithms into identical implementations.
+## Read first
 
-## Design the smallest PyTorch-compatible API
+- Read [AGENTS.md](../../../AGENTS.md), the claimed algorithm, `pyperch/optim/base.py`,
+  neighboring optimizers, relevant `tests/optim/`, and
+  [docs/general_usage_guide.md](../../../docs/general_usage_guide.md).
+- Read affected notebooks through
+  [the notebook skill](../maintain-notebook-examples/SKILL.md) when semantics, public
+  API, or convergence examples may change.
+- Reproduce a bug through an ordinary end-to-end PyTorch usage path before fixing it.
 
-- Accept native PyTorch parameter iterables and preserve direct
-  `Optimizer(model.parameters(), ...)` usage and ordinary training loops.
-- Use closure evaluation when the algorithm needs to reevaluate a loss, following
-  the local optimizer pattern. Leave forward passes, loss construction, gradient
-  mode, evaluation, freezing, and device choices in normal PyTorch code.
-- Add only algorithm-specific options and state. Do not introduce trainers,
-  callbacks, model wrappers, estimator APIs, configuration layers, tensor or data
-  abstractions, or experiment-framework behavior.
-- Touch `pyperch/search/` or Optuna documentation only when the concern genuinely
-  belongs to hyperparameter search. Keep native Optuna trials and studies visible.
+## Invariants
 
-## Implement consistently
+- Accept native parameter iterables and parameter groups. Keep models, tensors,
+  losses, closures, forward passes, training loops, freezing, and devices in normal
+  PyTorch code. Add no trainer, wrapper, estimator, callback, configuration, or
+  experiment abstraction.
+- Keep the implementation recognizable as the claimed algorithm. Define its
+  proposal, acceptance, state transition, evaluation, and randomization semantics
+  before changing its API.
+- Mutate only trainable parameters. Apply group options to their own tensors and
+  keep joint-search settings optimizer-wide. Reject invalid or silently ineffective
+  settings when constructing or adding groups. Adding a group changes the joint
+  search space, so preserve model values and private RNG position while restarting
+  run bookkeeping.
+- Preserve parameter and returned-loss dtype and device. Use a private RNG for every
+  stochastic choice so equal seeds reproduce independently of PyTorch global RNG,
+  `None` starts a fresh private stream, and counter resets do not rewind it.
+- Count `function_evals` as actual closure calls. Use proposal units for RHC and SA
+  step counters and generation units for GA after initialization. Keep
+  `accepted_steps + rejected_steps == proposed_steps`.
+- Keep `best_loss` and its parameter checkpoint consistent. `restore_best()` restores
+  the global best and synchronizes current-loss bookkeeping without rewinding
+  counters, schedules, retained population, or RNG state.
+- Save enough optimizer state for deterministic continuation with a compatible model
+  and group layout. This includes common counters, losses, best parameters, group
+  defaults, and RNG state, plus RHC restart progress, SA temperature state, or GA
+  population and cached fitness.
+- Validate constructor, group, and loaded checkpoint values at the boundary. Avoid
+  redundant closure calls and full-model copies when a changed tensor or cached
+  fitness is sufficient.
 
-- Respect parameter groups, `requires_grad`, tensor dtype, and tensor device using
-  PyTorch operations. Preserve the public behavior of existing constructor defaults.
-- Follow the neighboring patterns for current and best parameters, best loss,
-  `restore_best()`, and the `function_evals`, `proposed_steps`, `accepted_steps`, and
-  `rejected_steps` counters. Adapt those patterns when the algorithm requires a
-  different meaning, and document the difference.
-- Consider reproducibility explicitly. Define how `random_state` affects proposals,
-  initialization, crossover, mutation, or acceptance, and avoid accidental reliance
-  on unrelated global random state.
-- Keep the patch focused. Record desirable adjacent refactors separately unless they
-  are required for correct behavior.
+## Algorithm contracts
 
-## Supply evidence and usage
+- RHC accepts non-worsening proposals. Schedule restarts by total proposed steps,
+  whether accepted or rejected, preserve the global best across restarts, and treat
+  the first evaluation after a restart as an evaluation rather than a proposal.
+- SA accepts non-worsening proposals and accepts a worse proposal with Metropolis
+  probability `exp(-loss increase / temperature)`. Cool after each proposal and
+  respect the configured temperature floor.
+- GA initializes one population once, then retains it across calls. Preserve a
+  deterministic best-half elite set, with at least one elite and cached fitness.
+  Create and evaluate only new children through uniform crossover and group-scaled
+  mutation, and make each later call one generation. Keep current model parameters
+  aligned with the best current individual and checkpoint the full population and
+  its fitness while preserving the global best separately.
 
-- Add focused tests under `tests/optim/` for the algorithm behavior, validation,
-  counters and state, reproducibility where relevant, frozen parameters, and backward
-  compatibility affected by the change. Prefer observable behavior over private
-  implementation assertions.
-- Update the relevant notebook listed in `examples/README.md` with a runnable
-  example using a normal `torch.nn.Module`, native parameters, a loss closure, and
-  an ordinary loop. Follow that guide for notebook setup and execution.
-- Update `docs/general_usage_guide.md`, public exports, and README links only as the
-  public change requires.
+## Workflow
 
-## Validate and review
+1. State the behavior and counter units before implementation, including
+   initialization-only calls and all state transitions.
+2. Make the smallest source and test change that establishes that behavior.
+3. Update public exports, usage documentation, and affected examples only when the
+   public contract changes.
+4. Inspect the complete diff for abstraction creep, stale semantics, unrelated
+   search changes, sensitive data, local artifacts, and generated junk.
 
-Run the repository checks from `AGENTS.md`, including the focused optimizer tests and
-the runnable example when practical. Inspect the complete diff for API or abstraction
-creep, duplicated framework behavior, unrelated Optuna changes, stale documentation,
-secrets, local files, and generated artifacts.
+## Validation
+
+Scale evidence to touched behavior, then complete the required repository validation
+from `CONTRIBUTING.md`.
+
+- RNG or checkpoint work must prove private-RNG isolation and deterministic
+  uninterrupted versus resumed continuation.
+- Parameter-group work must exercise multiple groups; frozen-parameter work must
+  exercise frozen parameters.
+- Dtype or device work must cover the relevant supported dtype and every relevant
+  available supported device.
+- Counter or evaluation work must assert exact units and closure-call counts,
+  including initialization and cached evaluations.
+- Algorithm-semantic or public API work must run affected examples or notebooks and
+  check qualitative convergence, not only unit tests.
+- Validation-only changes may begin with focused rejection tests before broader
+  required validation.
+
+## Common failure modes
+
+- Using global randomness for one acceptance, crossover, or mutation path.
+- Treating initialization or monitoring as a proposal or GA generation.
+- Rebuilding a GA population or reevaluating known elites on every call.
+- Restoring parameter values without synchronizing cached current loss.
+- Copying frozen parameters into proposals or losing algorithm state at checkpoint.

--- a/.agents/skills/maintain-notebook-examples/SKILL.md
+++ b/.agents/skills/maintain-notebook-examples/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: maintain-notebook-examples
+description: Create or revise PyPerch executed teaching notebooks and example guidance while keeping native PyTorch usage, terminology, saved outputs, and plots accurate. Use for notebook behavior, public API, optimizer semantics, convergence, device, or example-presentation changes, not ordinary optimizer development or standalone experiments.
+---
+
+# Maintain notebook examples
+
+## When to use
+
+Use this skill for `examples/notebooks/`, their index, or behavior that changes what
+those notebooks teach. Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md) for setup and
+validation commands.
+
+## Read first
+
+- Read [AGENTS.md](../../../AGENTS.md), [examples/README.md](../../../examples/README.md),
+  the affected notebook, and the source, tests, and usage guide for every demonstrated
+  API.
+- Read [docs/plotting.md](../../../docs/plotting.md) for figures and
+  [docs/search.md](../../../docs/search.md) for Optuna examples.
+
+## Invariants
+
+- Keep the teaching path short and concept-led. Show ordinary PyTorch modules,
+  parameter iterables, closures, loops, freezing, devices, and evaluation directly.
+- Use current API names and precise terminology. Distinguish optimizer calls, RHC or
+  SA proposals, GA generations, objective evaluations, monitoring evaluations,
+  validation, and test evaluation.
+- Demonstrate `restore_best()` before reporting an optimizer's best result or before
+  final evaluation when current parameters may not be the global best.
+- Use relevant available devices for executable coverage and state unavailable-device
+  coverage explicitly. Treat accelerator runs as compatibility evidence unless they
+  are designed as performance benchmarks.
+- Keep plotting composable with caller-owned Matplotlib Axes. Learning curves use
+  training sample counts, training curves label actual iteration, generation, or
+  evaluation units, and model-complexity validation curves vary a real capacity
+  hyperparameter.
+- Keep Optuna studies and trials visible. Refit the selected best configuration,
+  restore its best parameters, and evaluate that model. Preserve clear optional
+  dependency behavior.
+
+## Workflow
+
+1. Identify the smallest affected notebook set and update code, narrative, labels,
+   saved outputs, and example index together.
+2. When notebook behavior or output, optimizer semantics, public API, or convergence
+   claims change, execute affected notebooks from fresh kernels using the workflow in
+   `CONTRIBUTING.md`. Run the full set when shared behavior can affect all notebooks.
+3. Check qualitative convergence and compare printed counters with the described
+   units. Visualize regenerated plots and inspect titles, axes, legends, uncertainty,
+   alt text, spacing, clipping, and readability.
+4. Keep temporary execution reports, HTML exports, caches, and local images out of
+   the patch unless the repository intentionally tracks that output.
+
+## Validation
+
+- Begin with the smallest affected notebook or example, then perform the broader
+  validation required by `CONTRIBUTING.md` for the touched behavior.
+- Confirm a fresh run succeeds without hidden interactive state, generated downloads,
+  private endpoints, personal paths, or undeclared dependencies.
+- Inspect notebook JSON only as a storage format; validate behavior by execution and
+  figures by visual review.
+
+## Common failure modes
+
+- Saving output from a warm kernel that no longer matches the code cells.
+- Renaming an API without updating prose, labels, counters, and neighboring notebooks.
+- Calling GA initialization a generation or presenting monitoring calls as optimizer
+  evaluations.
+- Leaving execution reports, exports, caches, or ad hoc plots in the diff.

--- a/.agents/skills/maintain-notebook-examples/SKILL.md
+++ b/.agents/skills/maintain-notebook-examples/SKILL.md
@@ -26,8 +26,9 @@ validation commands.
 - Use current API names and precise terminology. Distinguish optimizer calls, RHC or
   SA proposals, GA generations, objective evaluations, monitoring evaluations,
   validation, and test evaluation.
-- Demonstrate `restore_best()` before reporting an optimizer's best result or before
-  final evaluation when current parameters may not be the global best.
+- Demonstrate `restore_best()` before a reported result, comparison, or final
+  evaluation that claims the optimizer's best-found state. Preserve current
+  parameters when the intended claim is terminal-state performance.
 - Use relevant available devices for executable coverage and state unavailable-device
   coverage explicitly. Treat accelerator runs as compatibility evidence unless they
   are designed as performance benchmarks.
@@ -35,9 +36,9 @@ validation commands.
   training sample counts, training curves label actual iteration, generation, or
   evaluation units, and model-complexity validation curves vary a real capacity
   hyperparameter.
-- Keep Optuna studies and trials visible. Refit the selected best configuration,
-  restore its best parameters, and evaluate that model. Preserve clear optional
-  dependency behavior.
+- Keep Optuna studies and trials visible. Refit the selected best configuration and,
+  when its evaluation claims the optimizer's best-found state, restore its best
+  parameters before evaluating it. Preserve clear optional dependency behavior.
 
 ## Workflow
 

--- a/.agents/skills/run-reproducible-experiment/SKILL.md
+++ b/.agents/skills/run-reproducible-experiment/SKILL.md
@@ -1,49 +1,94 @@
 ---
 name: run-reproducible-experiment
-description: Run a comparative PyPerch optimizer experiment with a frozen implementation, fixed protocol, native PyTorch and Optuna use, and reproducible evidence. Use for experiments that compare optimizer settings or implementations, not ordinary optimizer development or generic model training.
+description: Run a comparative PyPerch optimizer experiment with a frozen implementation, explicit budgets, fixed seeds and settings, native PyTorch and Optuna use, and reproducible evidence. Use for comparisons or performance claims, not optimizer development or generic training.
 ---
 
 # Run a reproducible experiment
 
-Read the repository [agent guide](../../../AGENTS.md) first. State the experimental
-question, baseline, intended comparison, and claim the evidence could support before
-running anything.
+## When to use
 
-## Freeze the comparison
+Use this skill for comparisons among optimizer implementations or settings and for
+performance claims. Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md) to validate the
+implementation before freezing it.
 
-- Validate the implementation first, then freeze it for every run. Record the commit,
-  dirty status, relevant diff or file hashes, and dependency versions.
-- Give experiment workers read-only access to the implementation. Write runners,
-  logs, studies, and results outside the repository unless the task requests tracked
-  artifacts.
-- Fix the protocol before the first run: data split and preprocessing, model and
-  initialization, loss, optimizer calls, restoration of best parameters, metric,
-  budget, search space, sampler, direction, trial count, threading, and hardware.
-  Change only the intended comparison factor.
+## Read first
 
-## Keep PyTorch and Optuna visible
+- Read [AGENTS.md](../../../AGENTS.md), relevant optimizer source and tests,
+  [docs/general_usage_guide.md](../../../docs/general_usage_guide.md), and the affected
+  examples.
+- Read [docs/search.md](../../../docs/search.md) when Optuna is involved and
+  [docs/plotting.md](../../../docs/plotting.md) when preparing figures.
+- State the question, baseline, intended comparison, and claim the evidence could
+  support before running anything.
 
-Use ordinary PyTorch tensors, modules, losses, evaluation, and loops. Instantiate the
-PyPerch optimizer directly with native parameter iterables such as
-`GA(model.parameters(), ...)`. Account for optimizer semantics that affect the budget,
-including initialization-only calls and whether `restore_best()` is required before
-evaluation.
+## Invariants
 
-When search is needed, use the existing `OptunaSearch` layer without hiding its
-native `Study` or `Trial` objects. Record the exact Optuna distributions, including
-any approximation required by PyPerch's tuple format, and retain every completed,
-failed, and pruned trial state.
+- Freeze one validated implementation for all runs. Record the repository state,
+  dependency versions, hardware, command, warnings, failures, and limitations.
+- Fix and report seeds plus all comparison settings: data split and preprocessing,
+  model and initialization, loss, metric, optimizer configuration, restoration,
+  budgets, repeats, threading, device, search space, sampler, direction, and trial
+  count. Change only the declared comparison factor.
+- Use native PyTorch tensors, modules, losses, parameter iterables, evaluation, and
+  loops. Keep Optuna `Study` and `Trial` objects visible, retain every trial state,
+  and preserve documented optional-dependency behavior.
+- Tune and select with validation data. Keep test data untouched until final
+  evaluation. Refit the selected configuration, call `restore_best()` when the
+  optimizer contract requires it, and evaluate that restored model.
 
-## Make comparisons reproducible
+## Measurement units
 
-- Record every experiment seed and one deterministic per-trial seed rule. Seed each
-  random source the protocol uses and pass the trial seed to the PyPerch optimizer.
-- Tune and select on validation data. Keep test data untouched until the protocol's
-  final evaluation, and never select configurations from test results.
-- Record the command, repository snapshot, dirty files, environment, exact protocol,
-  trial budget and states, best trial and parameters, objective value, runtime,
-  warnings, failures, and limitations.
-- Compare runs only when their protocols match apart from the declared factor. Treat
-  small searches or inconsistent seed rules as exploratory evidence. Do not infer a
-  causal improvement from a jointly tuned parameter, tied validation scores, or a
-  small number of seeds and splits.
+Record these separately rather than treating them as interchangeable:
+
+- Optimizer iterations are explicit `step()` calls. For RHC and SA, the first call
+  initializes the loss and later calls propose moves.
+- GA population initialization is not a generation. Each later `step()` evolves one
+  persistent generation, and cached elite fitness avoids some objective calls.
+- Objective or function evaluations are actual optimizer closure calls, as reported
+  by `function_evals`.
+- Monitoring-only evaluations are extra forward evaluations used to record curves;
+  they are outside `function_evals` and must be reported separately.
+- Validation and test evaluations are also outside the optimizer budget and serve
+  selection and final assessment respectively.
+
+Equal optimizer-call counts do not imply equal objective calls or compute. Prefer a
+budget that matches the claim, report the other units, and include backward work,
+synchronization, or other excluded costs explicitly.
+
+## Workflow
+
+1. Write the fixed protocol and deterministic per-run or per-trial seed rule before
+   the first comparison.
+2. Keep runners, studies, logs, and results outside the repository unless tracked
+   artifacts are requested. Do not change the implementation after measurements
+   begin.
+3. Record per-run results and all completed, failed, and pruned trials. Compare only
+   protocols that differ by the declared factor.
+4. Present variation across seeds or splits and label exploratory evidence. Do not
+   infer causal improvement from jointly tuned values, tied validation results, or
+   a small sample.
+
+## Accelerator claims
+
+Treat CUDA or MPS coverage as compatibility and correctness unless the protocol
+actually benchmarks performance. Small randomized-optimization workloads can be
+slower on accelerators because of synchronization, kernel launch, transfer, and
+state-management overhead. Report timing methodology and warmup when making a speed
+claim.
+
+## Validation
+
+- Confirm the frozen implementation passes the concern-specific and repository
+  checks required by `CONTRIBUTING.md`.
+- Re-run a small deterministic slice before the full protocol and verify that
+  counters, restoration, seeds, recorded settings, and evaluation units are correct.
+- Inspect plots against `docs/plotting.md`; axes must name the actual iteration,
+  generation, sample-count, hyperparameter, or measured-evaluation unit.
+
+## Common failure modes
+
+- Comparing GA generations with RHC or SA proposals as though they cost the same.
+- Counting curve monitoring, validation, or test passes as optimizer function calls.
+- Reporting accelerator compatibility as a speedup without a benchmark.
+- Selecting from test results or evaluating the last trial instead of the refitted,
+  restored best configuration.

--- a/.agents/skills/run-reproducible-experiment/SKILL.md
+++ b/.agents/skills/run-reproducible-experiment/SKILL.md
@@ -33,8 +33,9 @@ implementation before freezing it.
   loops. Keep Optuna `Study` and `Trial` objects visible, retain every trial state,
   and preserve documented optional-dependency behavior.
 - Tune and select with validation data. Keep test data untouched until final
-  evaluation. Refit the selected configuration, call `restore_best()` when the
-  optimizer contract requires it, and evaluate that restored model.
+  evaluation. Refit the selected configuration. When a result, comparison, or final
+  evaluation claims the optimizer's best-found state, call `restore_best()` as the
+  optimizer contract requires before evaluating it.
 
 ## Measurement units
 
@@ -78,6 +79,8 @@ claim.
 
 ## Validation
 
+Scale validation rigor with the strength of the claim.
+
 - Confirm the frozen implementation passes the concern-specific and repository
   checks required by `CONTRIBUTING.md`.
 - Re-run a small deterministic slice before the full protocol and verify that
@@ -90,5 +93,5 @@ claim.
 - Comparing GA generations with RHC or SA proposals as though they cost the same.
 - Counting curve monitoring, validation, or test passes as optimizer function calls.
 - Reporting accelerator compatibility as a speedup without a benchmark.
-- Selecting from test results or evaluating the last trial instead of the refitted,
-  restored best configuration.
+- Selecting from test results or claiming best-found performance from the last trial
+  or an unrestored final state.

--- a/.agents/skills/run-reproducible-experiment/SKILL.md
+++ b/.agents/skills/run-reproducible-experiment/SKILL.md
@@ -40,7 +40,7 @@ implementation before freezing it.
 
 Record these separately rather than treating them as interchangeable:
 
-- Optimizer iterations are explicit `step()` calls. For RHC and SA, the first call
+- Optimizer step calls are explicit `step()` invocations. For RHC and SA, the first call
   initializes the loss and later calls propose moves.
 - GA population initialization is not a generation. Each later `step()` evolves one
   persistent generation, and cached elite fitness avoids some objective calls.
@@ -59,9 +59,9 @@ synchronization, or other excluded costs explicitly.
 
 1. Write the fixed protocol and deterministic per-run or per-trial seed rule before
    the first comparison.
-2. Keep runners, studies, logs, and results outside the repository unless tracked
-   artifacts are requested. Do not change the implementation after measurements
-   begin.
+2. Keep runners, studies, logs, and results in a task-authorized untracked location
+   unless tracked artifacts are requested. Do not change the implementation after
+   measurements begin.
 3. Record per-run results and all completed, failed, and pruned trials. Compare only
    protocols that differ by the declared factor.
 4. Present variation across seeds or splits and label exploratory evidence. Do not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ plus a thin Optuna search layer for optional hyperparameter studies.
 | `pyperch/plotting/` | Result preparation and rendering on caller-owned Axes |
 | `examples/notebooks/` | Executed concept-led PyTorch and Optuna notebooks |
 | `examples/README.md` | Notebook setup and reproducibility guidance |
-| `docs/` | General optimizer and search usage guides |
+| `docs/` | Optimizer, search, and plotting usage guides |
 | `pyproject.toml` | Supported Python versions, dependencies, and tool settings |
 
 ## Validation
@@ -45,7 +45,7 @@ Follow the validation requirements and commands in the
 - Do not add telemetry, network calls, downloads, or dependencies without a project
   requirement.
 - Before handoff, inspect the final diff for credentials, sensitive information,
-  generated artifacts, and local files.
+  local artifacts, and generated junk.
 
 ## Skill routing
 
@@ -53,6 +53,7 @@ Follow the validation requirements and commands in the
 | --- | --- |
 | Add or change an optimizer | [`.agents/skills/add-or-modify-optimizer/SKILL.md`](.agents/skills/add-or-modify-optimizer/SKILL.md) |
 | Run a comparative experiment | [`.agents/skills/run-reproducible-experiment/SKILL.md`](.agents/skills/run-reproducible-experiment/SKILL.md) |
+| Maintain an executed notebook or example | [`.agents/skills/maintain-notebook-examples/SKILL.md`](.agents/skills/maintain-notebook-examples/SKILL.md) |
 | Other work | This guide and the nearest implementation, test, example, and documentation |
 
 ## Project documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,10 @@ paths and commands, scope, and the complete diff. Tests are necessary evidence, 
 they do not by themselves establish algorithm correctness, API quality, backward
 compatibility, or performance claims.
 
-For notebook or plotting changes, also install the notebook extra and execute every
-notebook from a fresh kernel:
+For changes to notebook behavior or output, optimizer semantics or public APIs shown
+in notebooks, convergence claims, or plotting behavior demonstrated there, also
+install the notebook extra and execute the affected notebooks from fresh kernels.
+The repository runner executes the complete notebook set:
 
 ```bash
 poetry install --extras notebooks
@@ -71,7 +73,9 @@ The plotting contract and accepted array shapes live in [docs/plotting.md](docs/
   `model.parameters()` use, and avoid trainers, model wrappers, estimator APIs, or
   configuration frameworks.
 - Examples should be runnable ordinary PyTorch programs. Keep data preparation,
-  models, losses, evaluation, freezing, and device handling visible.
+  models, losses, evaluation, freezing, and device handling visible. Follow the
+  [notebook skill](.agents/skills/maintain-notebook-examples/SKILL.md) when changing
+  an executed notebook or its example guidance.
 - Compatibility changes should account for the declared Python and PyTorch ranges,
   constructor defaults, public imports, parameter dtype and device, and frozen
   parameters where relevant.


### PR DESCRIPTION
## Intent

Update existing PyPerch PR 32 on fm/pyperch-agent-harness from its remote head with the captain-reviewed wording changes, without creating a replacement PR or merging. Limit the patch to four documentation refinements: soften exact GA operator guidance so the optimizer skill preserves stable documented selection, crossover, mutation, fitness-caching, and population semantics without prescribing volatile details such as a specific elite fraction, crossover operator, or mutation form unless the public contract requires them; soften counter guidance so accepted plus rejected is not stated as an unconditional cross-algorithm invariant and initialization plus algorithm-specific units remain distinct; require restore_best() when a reported result, comparison, or final evaluation claims the optimizer best-found state rather than for every result; and state concisely that validation rigor scales with claim strength. Review surrounding passages only for consistency, including the best-found common failure wording. Do not broaden scope, refactor product code, add skills, or rewrite unrelated harness text. Preserve concise PyTorch-first and security guidance. Run the smallest relevant documentation, link, skill-package, formatting, and lint checks, then update the existing PR and stop once CI is green.

## What Changed

- Strengthen optimizer guidance around PyTorch compatibility, algorithm semantics, state continuity, counters, checkpointing, and claim-scaled validation.
- Add a notebook maintenance skill covering executable examples, precise terminology, best-state restoration, device coverage, and visual review.
- Expand reproducible experiment guidance with explicit budgets, evaluation units, fixed protocols, accelerator claims, and contributor workflow links.

## Risk Assessment

✅ Low: The documentation-only changes are well bounded, satisfy the four requested wording refinements, and the prior restore_best() finding is correctly resolved without altering terminal-state guidance.

## Testing

No baseline commands were supplied. Targeted validation exercised all three skills through the official package validator, resolved all 31 changed-document links, checked patch whitespace, and verified the four wording refinements against the prior PR head; all checks passed. No screenshot was captured because this is a non-UI Markdown skill-package change, and no formatter or linter was run because this assigned test phase explicitly prohibits them.

<details>
<summary>Evidence: Skill-package and link validation</summary>

```text
The official validator reported “Skill is valid!” for all three skill packages. All 31 local Markdown links across the five changed documents resolved successfully.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1d3d736d11289e8768b4901abaaf4cbc1b199a6a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.agents/skills/maintain-notebook-examples/SKILL.md:29` - Intent requires `restore_best()` only “when a reported result, comparison, or final evaluation claims the optimizer best-found state,” but this new skill says to restore before any final evaluation whenever current parameters may differ, and line 38 also mandates restoration unconditionally after refitting. For a notebook intentionally reporting terminal-state performance, this silently changes the result to best-found performance. Confirm whether both instructions should be conditioned on an explicit best-found claim.

🔧 Fix: Condition best-state restoration guidance
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/add-or-modify-optimizer`
- `python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/maintain-notebook-examples`
- `python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/run-reproducible-experiment`
- <code>Inline Python local-Markdown-link validation across `AGENTS.md`, `CONTRIBUTING.md`, and all three changed `SKILL.md` files</code>
- `git diff --check 126b2002ea3afa7a4b5e9e74e6e462644d0bb14c..1d3d736d11289e8768b4901abaaf4cbc1b199a6a`
- <code>Manual intent review of `git diff 4845d93..1d3d736 -- .agents/skills AGENTS.md CONTRIBUTING.md`</code>
- `git status --short`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
